### PR TITLE
Enable WSL logins bouncer for self- or admin-created accounts when bouncer registration disabled

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -702,8 +702,8 @@ function wsl_process_login_hybridauth_authenticate( $provider, $redirect_to )
 				}
 			}
 
-			// if user do not exist
-			if( ! $hybridauth_user_id ){
+			// if user does not exist
+			if( ! email_exists($hybridauth_user_email) ){
 				// Bouncer :: Accept new registrations
 				if( get_option( 'wsl_settings_bouncer_registration_enabled' ) == 2 ){
 					return wsl_render_notices_pages( _wsl__("registration is now closed!", 'wordpress-social-login') ); 


### PR DESCRIPTION
Submitting the fix suggested by knsheely on the wordpress.org WSL support forum: http://wordpress.org/support/topic/setting-accept-new-registration-to-no-restricts-current-users-from-logging-in. It works great for me.

The most important benefit is that it enables invitation-only sites to integrate WSL, where accounts are created by admins.

Thanks! 
