### PR TITLE
Support elements added at a later time

### DIFF
--- a/assets/js/connect.js
+++ b/assets/js/connect.js
@@ -2,7 +2,7 @@
 
 (function($){ 
 	$(function(){
-		$(".wsl_connect_with_provider").click(function(){
+		$(document).on("click", "a.wsl_connect_with_provider", function(){
 			popupurl = $("#wsl_popup_base_url").val();
 			provider = $(this).attr("data-provider");
 


### PR DESCRIPTION
Hi there,

I used the plugin for wordpress and it is awesome. It works like a charm. Thanks, saved me some time.

However, I had to make changes to connect.js in order to support the elements added at a later time. 
In my case, it was a popup login modal which simply uses the plugin's shortcode to show the social buttons.

click() is a direct binding, it won't get bound to elements added in the future.
on() is a delegated binding that supports descendant elements that are added to the document at a later time.
