### PR TITLE
Update wp-social-login.php

### DIFF
--- a/wp-social-login.php
+++ b/wp-social-login.php
@@ -81,7 +81,7 @@ defined( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH' )
 	|| define( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH', WP_PLUGIN_DIR . '/wordpress-social-login' );
 
 defined( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL' ) 
-	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', WP_PLUGIN_URL . '/wordpress-social-login' );
+	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', plugins_url() . '/wordpress-social-login' );
 
 defined( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL' ) 
 	|| define( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL', WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/hybridauth/' );


### PR DESCRIPTION
Fix - Problem with login images protocol match with page protocol(https/http).

Error message from chrome console:
The page was loaded over HTTPS, but displayed insecure content from 'http://****/plugins/wordpress-social-login/assets/img/32x32/wpzoom/facebook.png': this content should also be loaded over HTTPS.

Info link: https://wordpress.org/support/topic/dont-use-wp_plugin_url
