### PR TITLE
Allow parameters for authentication.

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -215,7 +215,8 @@ function wsl_process_login_begin()
 		// > after that, the provider will redirect the user back to this same page (and this same line). 
 		// > if the user is successfully connected to provider, then this time hybridauth::authenticate()
 		// > will just return the provider adapter
-		$adapter = $hybridauth->authenticate( $provider );
+		$params = apply_filters("wsl_hook_process_login_authenticate_params",array(),$provider);
+		$adapter = $hybridauth->authenticate( $provider,$params );
 	}
 
 	// if hybridauth fails to authenticate the user, then we display an error message


### PR DESCRIPTION
Certain providers require additional parameters for actions during authentication.  For example Facebook will only show permissions once if they are declined.  The require that you include the auth_type parameter with a value of rerequest to show them again.  HybridAuth accounts for this by allowing parameters to be include in the second argument of authenticate.  This addition allows other programmers to use the filter to add their own parameters.  This should be done by adding the parameters to the existing array that is passed in.  The $provider value can be used to serve the proper parameters as needed.