### PR TITLE
Fix incorrect field name for user_login

### DIFF
--- a/includes/widgets/wsl.users.gateway.php
+++ b/includes/widgets/wsl.users.gateway.php
@@ -570,7 +570,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 								<label>
 									<?php _wsl_e( "Username", 'wordpress-social-login' ); ?>
 									<br />
-									<input type="text" name="user_name" class="input" value="<?php echo $requested_user_login; ?>" size="25" placeholder="" />
+									<input type="text" name="user_login" class="input" value="<?php echo $requested_user_login; ?>" size="25" placeholder="" />
 								</label>
 
 								<label>


### PR DESCRIPTION
Updated to the correct variable name so that user input is saved correctly. Resolve #55