### PR TITLE
A quick fix for site_url() vs home_url()

### DIFF
--- a/includes/admin/components/tools/wsl.components.tools.actions.job.php
+++ b/includes/admin/components/tools/wsl.components.tools.actions.job.php
@@ -7,9 +7,9 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_tools_do_diagnostics()
 {
@@ -23,9 +23,9 @@ function wsl_component_tools_do_diagnostics()
 		<h3>
 			<label><?php _wsl_e("WordPress Social Login Diagnostics", 'wordpress-social-login') ?></label>
 		</h3>
-		<div class="inside"> 
+		<div class="inside">
 			<br />
-			<table class="wp-list-table widefat"> 
+			<table class="wp-list-table widefat">
 				<?php
 					$test = version_compare( PHP_VERSION, '5.2.0', '>=' );
 					// $test = 0;
@@ -38,9 +38,9 @@ function wsl_component_tools_do_diagnostics()
 						<p>PHP >= 5.2.0 installed.</p>
 						<?php
 							if( ! $test )
-							{ 
+							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error</b>: An old version of PHP is installed.</p>
 										<p>The solution is to make a trouble ticket to your web host and request them to upgrade to newer version of PHP.</p>
 									</div>
@@ -49,18 +49,18 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td width="60">
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
 							}
 							else
-							{ 
+							{
 								echo "<b style='color:red;'>FAIL!</b>";
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = isset( $_SESSION["wsl::plugin"] ) && $_SESSION["wsl::plugin"];
@@ -74,18 +74,18 @@ function wsl_component_tools_do_diagnostics()
 						<p>PHP/Session must be enabled and working.</p>
 						<?php
 							if( ! $test )
-							{ 
+							{
 								?>
-								<div class="fade error" style="margin: 20px  0;"> 
+								<div class="fade error" style="margin: 20px  0;">
 									<p><b>Error</b>: PHP Sessions are not working as expected.</p>
 
 									<p>
 										This error may occur for many reasons:
-									</p> 
+									</p>
 
 									<p>
 										1. PHP session are either disabled, renamed or there is files permissions issues.
-									</p> 
+									</p>
 									<p>
 										2. When using a reverse proxy like Varnish or a caching engine that might strip cookies. On this case, WSL will requires these two urls to be white-listed:
 									</p>
@@ -101,12 +101,12 @@ function wsl_component_tools_do_diagnostics()
 							}
 							else
 							{
-						?> 
+						?>
 							<hr />
 							<h4>Notes:</h4>
 							<p>
 								1. If you're hosting your website on <b>WP Engine</b>, refer this topic: <a href="https://wordpress.org/support/topic/500-internal-server-error-when-redirecting" target="_blank">https://wordpress.org/support/topic/500-internal-server-error-when-redirecting</a>
-							</p> 
+							</p>
 							<p>2. In case you're using a reverse proxy like Varnish or a caching engine that might strip cookies, WSL will requires these two urls to be white-listed:</p>
 							<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 								<?php
@@ -120,18 +120,18 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
 							}
 							else
-							{ 
+							{
 								echo "<b style='color:red;'>FAIL!</b>";
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = false;
@@ -153,11 +153,11 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>PHP CURL extension with SSL must be enabled and working.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error</b>: CURL library is either not installed or SSL is not enabled.</p>
 										<p>The solution is to make a trouble ticket to your web host and request them to enable the PHP CURL.</p>
 									</div>
@@ -166,18 +166,18 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
 							}
 							else
-							{ 
+							{
 								echo "<b style='color:red;'>FAIL!</b>";
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = ! ini_get('register_globals') ? true : false;
@@ -189,11 +189,11 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>PHP Register Globals must be OFF.</p>
-					<?php 
+					<?php
 						if(  ! $test )
-						{ 
+						{
 							?>
-								<div class="fade error" style="margin: 20px  0;"> 
+								<div class="fade error" style="margin: 20px  0;">
 									<p><b>Error</b>: REGISTER_GLOBALS are On.</p>
 									<p>This will prevent WSL from working properly and will result on an infinite loop on the authentication page.</p>
 									<p>The solution is to make a trouble ticket with your web host to disable it, Or, if you have a dedicated server and you know what are you doing then edit php.ini file and turn it Off.</p>
@@ -203,13 +203,13 @@ function wsl_component_tools_do_diagnostics()
 					?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
 							}
 							else
-							{ 
+							{
 								echo "<b style='color:red;'>FAIL!</b>";
 							}
 						?>
@@ -234,10 +234,10 @@ function wsl_component_tools_do_diagnostics()
 							<p>In any case, WSL requires this url to be white-listed:</p>
 
 							<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
-								<?php 
+								<?php
 									echo '<a href="' . WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL . '" target="_blank">' . WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL . '</a>';
 								?>
-							</div> 
+							</div>
 						</div>
 
 						<div id="end_points_note" style="margin: 20px  0;">
@@ -249,7 +249,7 @@ function wsl_component_tools_do_diagnostics()
 								<?php
 									echo '<a href="' . WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL . '" target="_blank">' . WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL . '</a>';
 								?>
-							</div> 
+							</div>
 						</div>
 
 						<p>You may double-check this test manually by clicking this <a href="<?php echo WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL; ?>?test=http://example.com" target="_blank">direct link</a>.</p>
@@ -275,7 +275,7 @@ function wsl_component_tools_do_diagnostics()
 							});
 						</script>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					global $wpdb;
@@ -291,11 +291,11 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>Check if WSL database tables (<code>wslusersprofiles</code> and <code>wsluserscontacts</code>) exist.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error:</b> One or more of WordPress Social Login tables do not exist.</p>
 										<p>This may prevent this plugin form working correctly. To fix this, navigate to <b>Tools</b> tab then <b><a href="options-general.php?page=wordpress-social-login&wslp=tools#repair-tables">Repair WSL tables</a></b>.</p>
 									</div>
@@ -315,25 +315,25 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
-			
+				</tr>
+
 				<?php
 					$test = class_exists( 'Hybrid_Auth', false ) ? false : true;
-				?> 				
+				?>
 				<tr>
 					<th width="200">
 						<label>Hybridauth Library</label>
 					</th>
 					<td>
 						<p>Check if the Hybridauth Library is auto-loaded by another plugin.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p>Hybridauth Library is auto-included by another plugin.</p>
 										<p>This is not critical but it may prevent WSL from working.</p>
-										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Hybridauth Library only when required.</p> 
+										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Hybridauth Library only when required.</p>
 										<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 										<?php try{$reflector = new ReflectionClass( 'Hybrid_Auth' ); echo $reflector->getFileName(); } catch( Exception $e ){} ?>
 										</div>
@@ -343,7 +343,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -355,24 +355,24 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 				</tr>
-	
+
 				<?php
 					$test = class_exists( 'OAuthConsumer', false ) ? false : true;
-				?> 
+				?>
 				<tr>
 					<th width="200">
 						<label>OAUTH Library</label>
 					</th>
 					<td>
 						<p>Check if OAUTH Library is auto-loaded by another plugin.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p>OAUTH Library is auto-included by another plugin.</p>
 										<p>This is not critical but it may prevent Twitter, LinkedIn and few other providers from working.</p>
-										<p>Please, inform the developer of that plugin not to auto-include the file below and to use OAUTH Library only when required.</p> 
+										<p>Please, inform the developer of that plugin not to auto-include the file below and to use OAUTH Library only when required.</p>
 										<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 										<?php try{$reflector = new ReflectionClass( 'OAuthConsumer' ); echo $reflector->getFileName(); } catch( Exception $e ){} ?>
 										</div>
@@ -382,7 +382,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -393,25 +393,25 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = class_exists( 'BaseFacebook', false ) ? false : true;
-				?> 
+				?>
 				<tr>
 					<th width="200">
 						<label>Facebook SDK</label>
 					</th>
 					<td>
 						<p>Check if Facebook SDK is auto-loaded by another plugin.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error:</b> Facebook SDK is auto-included by another plugin.</p>
 										<p>This will prevent Facebook from working.</p>
-										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Facebook SDK only when required.</p> 
+										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Facebook SDK only when required.</p>
 										<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 										<?php try{$reflector = new ReflectionClass( 'BaseFacebook' ); echo $reflector->getFileName(); } catch( Exception $e ){} ?>
 										</div>
@@ -421,7 +421,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -432,25 +432,25 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = class_exists( 'LightOpenID', false ) ? false : true;
-				?> 				
+				?>
 				<tr>
 					<th width="200">
 						<label>Class LightOpenID</label>
 					</th>
 					<td>
 						<p>Check if the LightOpenID Class is auto-loaded by another plugin.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p>Class LightOpenID is auto-included by another plugin.</p>
 										<p>This is not critical but it may prevent Yahoo, Steam, and few other providers from working.</p>
-										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Class LightOpenID only when required.</p> 
+										<p>Please, inform the developer of that plugin not to auto-include the file below and to use Class LightOpenID only when required.</p>
 										<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 										<?php try{$reflector = new ReflectionClass( 'LightOpenID' ); echo $reflector->getFileName(); } catch( Exception $e ){} ?>
 										</div>
@@ -460,7 +460,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -496,11 +496,11 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>Check for proxified urls.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p>WSL has detected that you are using a proxy in your website. The URL shown below should match the URL on your browser address bar.</p>
 										<div style="background-color: #FFFFE0;border:1px solid #E6DB55; border-radius: 3px;padding: 10px;margin:2px;">
 											<?php
@@ -513,7 +513,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -524,10 +524,10 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
-				<?php 
-					$test = ! stristr( plugins_url(), site_url() ) ? false : true;
+				<?php
+					$test = ! stristr( plugins_url(), home_url() ) ? false : true;
 				?>
 				<tr>
 					<th width="200">
@@ -535,7 +535,7 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>Check for WordPress directories functions.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
@@ -546,7 +546,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -557,18 +557,18 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$test = true;
 					$used = array();
 
-					$depreciated = array( 
+					$depreciated = array(
 					// auth
-						'wsl_hook_process_login_alter_userdata', 
-						'wsl_hook_process_login_before_insert_user', 
-						'wsl_hook_process_login_after_create_wp_user', 
-						'wsl_hook_process_login_before_set_auth_cookie', 
+						'wsl_hook_process_login_alter_userdata',
+						'wsl_hook_process_login_before_insert_user',
+						'wsl_hook_process_login_after_create_wp_user',
+						'wsl_hook_process_login_before_set_auth_cookie',
 						'wsl_hook_process_login_before_redirect',
 
 					// widget
@@ -586,18 +586,18 @@ function wsl_component_tools_do_diagnostics()
 							$used[] = $v;
 						}
 					}
-				?> 				
+				?>
 				<tr>
 					<th width="200">
 						<label>WSL depreciated hooks</label>
 					</th>
 					<td>
 						<p>Check for depreciated WSL actions and filters in use.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p>WSL has detected that you are using depreciated WSL: <code><?php echo implode( '</code>, <code>', $used ); ?></code></p>
 										<p>Please update the WSL hooks you were using accordingly to the new developer API at <a href="http://miled.github.io/wordpress-social-login/documentation.html" target="_blank">http://miled.github.io/wordpress-social-login/documentation.html</a></p>
 									</div>
@@ -607,7 +607,7 @@ function wsl_component_tools_do_diagnostics()
 						<p> Note: this test is not reliable 100% as we simply match the depreciated hooks against <code>has_filter</code> and <code>has_action</code>.</p>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -618,24 +618,24 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					$itsec_tweaks = get_option( 'itsec_tweaks' );
 
 					$test = $itsec_tweaks && $itsec_tweaks['long_url_strings'] ? false : true;
-				?> 				
+				?>
 				<tr>
 					<th width="200">
 						<label>iThemes Security</label>
 					</th>
 					<td>
 						<p>Check if 'Prevent long URL strings' option is enabled.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error:</b> 'Prevent long URL strings' option is in enabled.</p>
 										<p>This may prevent Facebook and few other providers from working.</p>
 									</div>
@@ -644,7 +644,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -655,7 +655,7 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
+				</tr>
 
 				<?php
 					/**
@@ -691,11 +691,11 @@ function wsl_component_tools_do_diagnostics()
 					</th>
 					<td>
 						<p>Check if your web server clock is in sync.</p>
-						<?php 
+						<?php
 							if( ! $test )
 							{
 								?>
-									<div class="fade error" style="margin: 20px  0;"> 
+									<div class="fade error" style="margin: 20px  0;">
 										<p><b>Error:</b> <?php echo $error; ?>.</p>
 										<?php if( $hint ) echo '<p>' . $hint . '.</p>'; ?>
 									</div>
@@ -704,7 +704,7 @@ function wsl_component_tools_do_diagnostics()
 						?>
 					</td>
 					<td>
-						<?php 
+						<?php
 							if( $test )
 							{
 								echo "<b style='color:green;'>OK!</b>";
@@ -715,8 +715,8 @@ function wsl_component_tools_do_diagnostics()
 							}
 						?>
 					</td>
-				</tr> 
-			</table> 
+				</tr>
+			</table>
 
 			<br />
 			<hr />
@@ -730,7 +730,7 @@ function wsl_component_tools_do_diagnostics()
 
 add_action( 'wsl_component_tools_do_diagnostics', 'wsl_component_tools_do_diagnostics' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_tools_do_sysinfo()
 {
@@ -745,7 +745,7 @@ function wsl_component_tools_do_sysinfo()
 		<h3>
 			<label><?php _wsl_e("System information", 'wordpress-social-login') ?></label>
 		</h3>
-		<div class="inside"> 
+		<div class="inside">
 			<ul style="padding-left:15px;">
 				<li>Please include this information when posting support requests. It will help me immensely to better understand any issues.</li>
 				<li>These information should be communicated to the plugin developer <b>PRIVATELY VIA EMAIL</b> : Miled &lt;<a href="mailto:hybridauth@gmail.com">hybridauth@gmail.com</a>&gt;</li>
@@ -754,6 +754,7 @@ function wsl_component_tools_do_sysinfo()
 # GENERAL
 
 SITE_URL:                 <?php echo site_url() . "\n"; ?>
+HOME_URL:                 <?php echo home_url() . "\n"; ?>
 PLUGIN_URL:               <?php echo plugins_url() . "\n"; ?>
 
 # WORDPRESS SOCIAL LOGIN
@@ -808,16 +809,16 @@ HTTP_X_FORWARDED_PROTO:   <?php echo isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] )
 
 # ACTIVE PLUGINS
 
-<?php  
+<?php
 if( function_exists("get_plugins") ):
 	$plugins = get_plugins();
-	foreach ( $plugins as $plugin_path => $plugin ): 
-		echo str_pad( $plugin['Version'], 10, " ", STR_PAD_LEFT ); ?>. <?php echo $plugin['Name']."\n"; 
+	foreach ( $plugins as $plugin_path => $plugin ):
+		echo str_pad( $plugin['Version'], 10, " ", STR_PAD_LEFT ); ?>. <?php echo $plugin['Name']."\n";
 	endforeach;
 else:
 	$active_plugins = get_option( 'active_plugins', array() );
-	foreach ( $active_plugins as $plugin ): 
-		echo $plugin ."\n"; 
+	foreach ( $active_plugins as $plugin ):
+		echo $plugin ."\n";
 	endforeach;
 endif; ?>
 
@@ -834,7 +835,7 @@ if ( get_bloginfo( 'version' ) < '3.4' ) {
 ?>
 
 
-# EOF</textarea> 
+# EOF</textarea>
 
 			<br />
 			<br />
@@ -847,14 +848,14 @@ if ( get_bloginfo( 'version' ) < '3.4' ) {
 
 add_action( 'wsl_component_tools_do_sysinfo', 'wsl_component_tools_do_sysinfo' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_tools_do_repair()
 {
 	global $wpdb;
 
 	wsl_database_install();
-	
+
 	// update_option( 'wsl_settings_development_mode_enabled', 1 );
 ?>
 <div class="metabox-holder columns-2" id="post-body">
@@ -862,7 +863,7 @@ function wsl_component_tools_do_repair()
 		<h3>
 			<label><?php _wsl_e("Repair Wordpress Social Login tables", 'wordpress-social-login') ?></label>
 		</h3>
-		<div class="inside"> 
+		<div class="inside">
 			<p>
 				<?php _wsl_e("All Wordpress Social Login tables and fields <em>should</em> be now restored", 'wordpress-social-login') ?>.
 			</p>
@@ -874,7 +875,7 @@ function wsl_component_tools_do_repair()
 		</div>
 	</div>
 </div>
-<?php 
+<?php
 	# ain't this clever :p
 	$db_check_profiles = $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}wslusersprofiles'" ) === $wpdb->prefix . 'wslusersprofiles' ? 1 : 0;
 	$db_check_contacts = $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}wsluserscontacts'" ) === $wpdb->prefix . 'wsluserscontacts' ? 1 : 0;
@@ -890,7 +891,7 @@ function wsl_component_tools_do_repair()
 
 add_action( 'wsl_component_tools_do_repair', 'wsl_component_tools_do_repair' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_tools_do_uninstall()
 {
@@ -901,7 +902,7 @@ function wsl_component_tools_do_uninstall()
 		<h3>
 			<label><?php _wsl_e("Uninstall", 'wordpress-social-login') ?></label>
 		</h3>
-		<div class="inside"> 
+		<div class="inside">
 			<p>
 				<?php _wsl_e("All Wordpress Social Login tables and stored options are permanently deleted from your WordPress database", 'wordpress-social-login') ?>.
 			</p>
@@ -924,4 +925,4 @@ function wsl_component_tools_do_uninstall()
 
 add_action( 'wsl_component_tools_do_uninstall', 'wsl_component_tools_do_uninstall' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -10,10 +10,10 @@
 * Authenticate users via social networks.
 *
 * Ref: http://miled.github.io/wordpress-social-login/developer-api-authentication.html
-** 
+**
 * Side note: I don't usually over-comment codes, but this is the main WSL script and I had to since
 *            many users with diffrent "skill levels" may want to understand how this piece of code works.
-** 
+**
 * To sum things up, here is how WSL works (bit hard to explain, so bare with me):
 *
 * Let assume a user come to page at our website and he click on of the providers icons in order connect.
@@ -65,7 +65,7 @@ if( !defined( 'ABSPATH' ) ) exit;
 * This function runs after WordPress has finished loading but before any headers are sent.
 * This function will analyse the current URL parameters and start the login process whenever an
 * WSL action is found: $_REQUEST['action'] eq wordpress_social_*
-* 
+*
 * Example of valid origin url:
 *    wp-login.php
 *       ?action=wordpress_social_authenticate                        // current step
@@ -107,7 +107,7 @@ function wsl_process_login()
 		return wsl_process_login_render_notice_page( sprintf( _wsl__( "You have to be logged in to be able to link your existing account. Do you want to <a href='%s'>login</a>?", 'wordpress-social-login' ), wp_login_url( home_url() ) ) );
 	}
 
-	// halt, if mode test and not admin 
+	// halt, if mode test and not admin
 	if( 'test' == $auth_mode && ! current_user_can('manage_options') )
 	{
 		return wsl_process_login_render_notice_page( _wsl__( 'You do not have sufficient permissions to access this page.', 'wordpress-social-login' ) );
@@ -142,10 +142,10 @@ add_action( 'init', 'wsl_process_login' );
 
 /**
 * Start the first part of authentication
-* 
+*
 * Steps:
 *     1. Display a loading screen while hybridauth is redirecting the user to the selected provider
-*     2. Build the hybridauth config for the selected provider (keys, scope, etc) 
+*     2. Build the hybridauth config for the selected provider (keys, scope, etc)
 *     3. Instantiate the class Hybrid_Auth and redirect the user to provider to ask for authorisation for this website
 *     4. Display a loading screen after user come back from provider as we redirect the user back to Widget::Redirect URL
 */
@@ -157,12 +157,12 @@ function wsl_process_login_begin()
 	$config     = null;
 	$hybridauth = null;
 	$provider   = null;
-	$adapter    = null; 
+	$adapter    = null;
 
 	// check if php session are working as expected by wsl
 	if( ! wsl_process_login_check_php_session() )
 	{
-		return wsl_process_login_render_notice_page( sprintf( _wsl__( 'The session identifier is missing.<br />For more information refer to WSL <a href="http://miled.github.io/wordpress-social-login/troubleshooting.html#session-error" target="_blank">Troubleshooting</a>.', 'wordpress-social-login' ), site_url() ) );
+		return wsl_process_login_render_notice_page( sprintf( _wsl__( 'The session identifier is missing.<br />For more information refer to WSL <a href="http://miled.github.io/wordpress-social-login/troubleshooting.html#session-error" target="_blank">Troubleshooting</a>.', 'wordpress-social-login' ), home_url() ) );
 	}
 
 	// HOOKABLE: selected provider name
@@ -170,7 +170,7 @@ function wsl_process_login_begin()
 
 	if( ! $provider )
 	{
-		return wsl_process_login_render_notice_page( _wsl__( 'Bouncer says this makes no sense.', 'wordpress-social-login' ) ); 
+		return wsl_process_login_render_notice_page( _wsl__( 'Bouncer says this makes no sense.', 'wordpress-social-login' ) );
 	}
 
 	/* 1. Display a loading screen while hybridauth is redirecting the user to the selected provider */
@@ -198,7 +198,7 @@ function wsl_process_login_begin()
 	// load hybridauth main class
 	if( ! class_exists('Hybrid_Auth', false) )
 	{
-		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "/hybridauth/Hybrid/Auth.php"; 
+		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "/hybridauth/Hybrid/Auth.php";
 	}
 
 	// HOOKABLE:
@@ -206,13 +206,13 @@ function wsl_process_login_begin()
 
 	try
 	{
-		// create an instance oh hybridauth with the generated config 
+		// create an instance oh hybridauth with the generated config
 		$hybridauth = new Hybrid_Auth( $config );
 
 		// start the authentication process via hybridauth
 		// > if not already connected hybridauth::authenticate() will redirect the user to the provider
-		// > where he will be asked for his consent (most providers ask for consent only once). 
-		// > after that, the provider will redirect the user back to this same page (and this same line). 
+		// > where he will be asked for his consent (most providers ask for consent only once).
+		// > after that, the provider will redirect the user back to this same page (and this same line).
 		// > if the user is successfully connected to provider, then this time hybridauth::authenticate()
 		// > will just return the provider adapter
 		$params = apply_filters("wsl_hook_process_login_authenticate_params",array(),$provider);
@@ -236,7 +236,7 @@ function wsl_process_login_begin()
 	// authentication mode
 	$auth_mode = wsl_process_login_get_auth_mode();
 
-	$redirect_to = isset( $_REQUEST[ 'redirect_to' ] ) ? $_REQUEST[ 'redirect_to' ] : site_url();
+	$redirect_to = isset( $_REQUEST[ 'redirect_to' ] ) ? $_REQUEST[ 'redirect_to' ] : home_url();
 
 	// build the authenticateD, which will make wsl_process_login() fire the next step wsl_process_login_end()
 	$authenticated_url = site_url( 'wp-login.php', 'login_post' ) . ( strpos( site_url( 'wp-login.php', 'login_post' ), '?' ) ? '&' : '?' ) . "action=wordpress_social_authenticated&provider=" . $provider . '&mode=' . $auth_mode;
@@ -248,8 +248,8 @@ function wsl_process_login_begin()
 // --------------------------------------------------------------------
 
 /**
-* Finish the authentication process 
-* 
+* Finish the authentication process
+*
 * Steps:
 *     1. Get the user profile from provider
 *     2. Create new wordpress user if he didn't exist in database
@@ -271,9 +271,9 @@ function wsl_process_login_end()
 	$auth_mode = wsl_process_login_get_auth_mode();
 
 	$is_new_user             = false; // is it a new or returning user
-	$user_id                 = ''   ; // wp user id 
+	$user_id                 = ''   ; // wp user id
 	$adapter                 = ''   ; // hybriauth adapter for the selected provider
-	$hybridauth_user_profile = ''   ; // hybriauth user profile 
+	$hybridauth_user_profile = ''   ; // hybriauth user profile
 	$requested_user_login    = ''   ; // username typed by users in Profile Completion
 	$requested_user_email    = ''   ; // email typed by users in Profile Completion
 
@@ -313,14 +313,14 @@ function wsl_process_login_end()
 	}
 	elseif( 'login' != $auth_mode )
 	{
-		return wsl_process_login_render_notice_page( _wsl__( 'Bouncer says no.', 'wordpress-social-login' ) ); 
+		return wsl_process_login_render_notice_page( _wsl__( 'Bouncer says no.', 'wordpress-social-login' ) );
 	}
 
 	if( 'login' == $auth_mode )
 	{
-		// returns user data after he authenticate via hybridauth 
+		// returns user data after he authenticate via hybridauth
 		list
-		( 
+		(
 			$user_id                ,
 			$adapter                ,
 			$hybridauth_user_profile,
@@ -349,7 +349,7 @@ function wsl_process_login_end()
 		return wsl_process_login_render_notice_page( sprintf( _wsl__( "Sorry, we couldn't connect you. <a href=\"%s\">Please try again</a>.", 'wordpress-social-login' ), site_url( 'wp-login.php', 'login_post' ) ) );
 	}
 
-	// store user hybridauth profile (wslusersprofiles), contacts (wsluserscontacts) and buddypress mapping 
+	// store user hybridauth profile (wslusersprofiles), contacts (wsluserscontacts) and buddypress mapping
 	wsl_process_login_update_wsl_user_data( $is_new_user, $user_id, $provider, $adapter, $hybridauth_user_profile, $wp_user );
 
 	// finally create a wordpress session for the user
@@ -359,14 +359,14 @@ function wsl_process_login_end()
 // --------------------------------------------------------------------
 
 /**
-* Returns user data after he authenticate via hybridauth 
+* Returns user data after he authenticate via hybridauth
 *
 * Steps:
 *    1. Grab the user profile from hybridauth
 *    2. Run Bouncer::Filters if enabled (domains, emails, profiles urls)
 *    3. Check if user exist in database by looking for the couple (Provider name, Provider user ID) or verified email
 *    4. Deletegate detection of user id to custom functions / hooks
-*    5. If Bouncer::Profile Completion is enabled and user didn't exist, we require the user to complete the registration (user name & email) 
+*    5. If Bouncer::Profile Completion is enabled and user didn't exist, we require the user to complete the registration (user name & email)
 */
 function wsl_process_login_get_user_data( $provider, $redirect_to )
 {
@@ -381,7 +381,7 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 	$requested_user_login     = '';
 	$requested_user_email     = '';
 
-	/* 1. Grab the user profile from social network */ 
+	/* 1. Grab the user profile from social network */
 
 	if( ! ( isset( $_SESSION['wsl::userprofile'] ) && $_SESSION['wsl::userprofile'] && $hybridauth_user_profile = json_decode( $_SESSION['wsl::userprofile'] ) ) )
 	{
@@ -392,7 +392,7 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 
 	$adapter = wsl_process_login_get_provider_adapter( $provider );
 
-	$hybridauth_user_email = sanitize_email( $hybridauth_user_profile->email ); 
+	$hybridauth_user_email = sanitize_email( $hybridauth_user_profile->email );
 
 	/* 2. Run Bouncer::Filters if enabled (domains, emails, profiles urls) */
 
@@ -405,7 +405,7 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 		}
 
 		$list = get_option( 'wsl_settings_bouncer_new_users_restrict_domain_list' );
-		$list = preg_split( '/$\R?^/m', $list ); 
+		$list = preg_split( '/$\R?^/m', $list );
 
 		$current = strstr( $hybridauth_user_email, '@' );
 
@@ -496,7 +496,7 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 		}
 
 		$list = get_option( 'wsl_settings_bouncer_new_users_restrict_email_list' );
-		$list = preg_split( '/$\R?^/m', $list ); 
+		$list = preg_split( '/$\R?^/m', $list );
 
 		$shall_pass = false;
 
@@ -516,10 +516,10 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 
 	// Bouncer::Filters by profile urls
 	if( get_option( 'wsl_settings_bouncer_new_users_restrict_profile_enabled' ) == 1 )
-	{ 
+	{
 		error_log(__METHOD__ . ' start restrict_profile_enabled.');
 		$list = get_option( 'wsl_settings_bouncer_new_users_restrict_profile_list' );
-		$list = preg_split( '/$\R?^/m', $list ); 
+		$list = preg_split( '/$\R?^/m', $list );
 		error_log(__METHOD__ . ' $list is ' . print_r($list, true));
 
 		$shall_pass = false;
@@ -545,7 +545,7 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 	// check if user already exist in wslusersprofiles
 	$user_id = (int) wsl_get_stored_hybridauth_user_id_by_provider_and_provider_uid( $provider, $hybridauth_user_profile->identifier );
 
-	// if not found in wslusersprofiles, then check his verified email 
+	// if not found in wslusersprofiles, then check his verified email
 	if( ! $user_id && ! empty( $hybridauth_user_profile->emailVerified ) )
 	{
 		// check if the verified email exist in wp_users
@@ -562,12 +562,12 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
 
 	/* 6. returns user data */
 
-	return array( 
+	return array(
 		$user_id,
 		$adapter,
-		$hybridauth_user_profile, 
-		$requested_user_login, 
-		$requested_user_email, 
+		$hybridauth_user_profile,
+		$requested_user_login,
+		$requested_user_email,
 	);
 }
 
@@ -586,7 +586,7 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 	$user_login = '';
 	$user_email = '';
 
-	// if coming from "complete registration form" 
+	// if coming from "complete registration form"
 	if( $requested_user_login )
 	{
 		$user_login = $requested_user_login;
@@ -649,7 +649,7 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 				$user_email = md5( uniqid( wp_rand( 10000, 99000 ) ) ) . '@example.com';
 			}
 			while( wsl_wp_email_exists( $user_email ) );
-		} 
+		}
 	}
 
 	$display_name = $hybridauth_user_profile->displayName;
@@ -671,14 +671,14 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		'display_name'  => $display_name,
 
 		'first_name'    => $hybridauth_user_profile->firstName,
-		'last_name'     => $hybridauth_user_profile->lastName, 
+		'last_name'     => $hybridauth_user_profile->lastName,
 		'user_url'      => $hybridauth_user_profile->profileURL,
 		'description'   => $hybridauth_user_profile->description,
 
 		'user_pass'     => wp_generate_password()
 	);
 
-	// Bouncer::Membership level  
+	// Bouncer::Membership level
 	$wsl_settings_bouncer_new_users_membership_default_role = get_option( 'wsl_settings_bouncer_new_users_membership_default_role' );
 
 	// if level eq "default", we set role to wp default user role
@@ -693,7 +693,7 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		$userdata['role'] = $wsl_settings_bouncer_new_users_membership_default_role;
 	}
 
-	// Bouncer::User Moderation 
+	// Bouncer::User Moderation
 	// > if Bouncer::User Moderation is enabled (Yield to Theme My Login), then we overwrite the user role to 'pending'
 	# http://www.jfarthing.com/development/theme-my-login/user-moderation/
 	if( get_option( 'wsl_settings_bouncer_new_users_moderation_level' ) > 100 )
@@ -733,7 +733,7 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		return wsl_process_login_render_notice_page( _wsl__( "An error occurred while creating a new user!", 'wordpress-social-login' ) );
 	}
 
-	// Send notifications 
+	// Send notifications
 	if( get_option( 'wsl_settings_users_notification' ) == 1 )
 	{
 		wsl_admin_notification( $user_id, $provider );
@@ -803,9 +803,9 @@ function wsl_process_login_authenticate_wp_user( $user_id, $provider, $redirect_
 	}
 
 	// Bouncer::User Moderation
-	// > When Bouncer::User Moderation is enabled, WSL will check for the current user role. If equal to 'pending', then Bouncer will do the following : 
-	// 	1. Halt the authentication process, 
-	// 	2. Skip setting the authentication cookies for the user, 
+	// > When Bouncer::User Moderation is enabled, WSL will check for the current user role. If equal to 'pending', then Bouncer will do the following :
+	// 	1. Halt the authentication process,
+	// 	2. Skip setting the authentication cookies for the user,
 	// 	3. Reset the Redirect URL to the appropriate Theme My Login page.
 	$wsl_settings_bouncer_new_users_moderation_level = get_option( 'wsl_settings_bouncer_new_users_moderation_level' );
 
@@ -859,10 +859,10 @@ function wsl_process_login_authenticate_wp_user( $user_id, $provider, $redirect_
 	do_action( 'wsl_clear_user_php_session' );
 
 	// Display WSL debugging instead of redirecting the user
-	// > this will give a complete report on what wsl did : database queries and fired hooks 
+	// > this will give a complete report on what wsl did : database queries and fired hooks
 	// wsl_display_dev_mode_debugging_area(); die(); // ! keep this line commented unless you know what you are doing :)
 
-	// That's it. We done. 
+	// That's it. We done.
 	wp_safe_redirect( $redirect_to );
 
 	// for good measures
@@ -877,7 +877,7 @@ function wsl_process_login_authenticate_wp_user( $user_id, $provider, $redirect_
 function wsl_process_login_build_provider_config( $provider )
 {
 	$config = array();
-	$config["base_url"] = WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL; 
+	$config["base_url"] = WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL;
 	$config["providers"] = array();
 	$config["providers"][$provider] = array();
 	$config["providers"][$provider]["enabled"] = true;
@@ -936,7 +936,7 @@ function wsl_process_login_build_provider_config( $provider )
 		}
 	}
 
-	$provider_scope = isset( $config["providers"][$provider]["scope"] ) ? $config["providers"][$provider]["scope"] : '' ; 
+	$provider_scope = isset( $config["providers"][$provider]["scope"] ) ? $config["providers"][$provider]["scope"] : '' ;
 
 	// HOOKABLE: allow to overwrite scopes
 	$config["providers"][$provider]["scope"] = apply_filters( 'wsl_hook_alter_provider_scope', $provider_scope, $provider );
@@ -950,7 +950,7 @@ function wsl_process_login_build_provider_config( $provider )
 // --------------------------------------------------------------------
 
 /**
-*  Grab the user profile from social network 
+*  Grab the user profile from social network
 */
 function wsl_process_login_request_user_social_profile( $provider )
 {
@@ -971,12 +971,12 @@ function wsl_process_login_request_user_social_profile( $provider )
 			// grab user profile via hybridauth api
 			$hybridauth_user_profile = $adapter->getUserProfile();
 		}
-		
+
 		// if user not connected to provider (ie: session lost, url forged)
 		else
 		{
 			return wsl_process_login_render_notice_page( sprintf( _wsl__( "Sorry, we couldn't connect you with <b>%s</b>. <a href=\"%s\">Please try again</a>.", 'wordpress-social-login' ), $provider, site_url( 'wp-login.php', 'login_post' ) ) );
-		} 
+		}
 	}
 
 	// if things didn't go as expected, we dispay the appropriate error message
@@ -1009,10 +1009,10 @@ function wsl_process_login_get_provider_adapter( $provider )
 * Returns redirect_to (callback url)
 *
 * By default, once a user  authenticate, he will be automatically redirected to the page where he come from (referer).
-* If WSL wasn't able to identify the referer url (or if the user come wp-login.php), then they will be redirected to 
-* Widget::Redirect URL instead. 
+* If WSL wasn't able to identify the referer url (or if the user come wp-login.php), then they will be redirected to
+* Widget::Redirect URL instead.
 *
-* When Widget::Force redirection is set to Yes, users will be always redirected to Widget::Redirect URL. 
+* When Widget::Force redirection is set to Yes, users will be always redirected to Widget::Redirect URL.
 *
 * Note: Widget::Redirect URL can be customised using the filter 'wsl_hook_process_login_alter_redirect_to'
 */
@@ -1042,24 +1042,24 @@ function wsl_process_login_get_redirect_to()
 		// we don't go there..
 		if( strpos( $redirect_to, 'wp-admin') )
 		{
-			$redirect_to = $wsl_settings_redirect_url; 
+			$redirect_to = $wsl_settings_redirect_url;
 		}
 
 		// nor there..
 		if( strpos( $redirect_to, 'wp-login.php') )
 		{
-			$redirect_to = $wsl_settings_redirect_url; 
+			$redirect_to = $wsl_settings_redirect_url;
 		}
 	}
 
 	if( empty( $redirect_to ) )
 	{
-		$redirect_to = $wsl_settings_redirect_url; 
+		$redirect_to = $wsl_settings_redirect_url;
 	}
 
 	if( empty( $redirect_to ) )
 	{
-		$redirect_to = site_url();
+		$redirect_to = home_url();
 	}
 
 	$redirect_to = apply_filters( 'wsl_hook_process_login_alter_redirect_to', $redirect_to );
@@ -1077,10 +1077,10 @@ function wsl_process_login_render_error_page( $e, $config = null, $provider = nu
 	// HOOKABLE:
 	do_action( "wsl_process_login_render_error_page", $e, $config, $provider, $adapter );
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
 
-	$message  = _wsl__("Unspecified error!", 'wordpress-social-login'); 
-	$notes    = ""; 
+	$message  = _wsl__("Unspecified error!", 'wordpress-social-login');
+	$notes    = "";
 	$apierror = substr( $e->getMessage(), 0, 145 );
 
 	switch( $e->getCode() )
@@ -1089,10 +1089,10 @@ function wsl_process_login_render_error_page( $e, $config = null, $provider = nu
 		case 1 : $message = _wsl__("WordPress Social Login is not properly configured.", 'wordpress-social-login'); break;
 		case 2 : $message = sprintf( __wsl__("WordPress Social Login is not properly configured.<br /> <b>%s</b> need to be properly configured.", 'wordpress-social-login'), $provider ); break;
 		case 3 : $message = _wsl__("Unknown or disabled provider.", 'wordpress-social-login'); break;
-		case 4 : $message = sprintf( _wsl__("WordPress Social Login is not properly configured.<br /> <b>%s</b> requires your application credentials.", 'wordpress-social-login'), $provider ); 
-			 $notes   = sprintf( _wsl__("<b>What does this error mean ?</b><br />Most likely, you didn't setup the correct application credentials for this provider. These credentials are required in order for <b>%s</b> users to access your website and for WordPress Social Login to work.", 'wordpress-social-login'), $provider ) . _wsl__('<br />Instructions for use can be found in the <a href="http://miled.github.io/wordpress-social-login/networks.html" target="_blank">User Manual</a>.', 'wordpress-social-login'); 
+		case 4 : $message = sprintf( _wsl__("WordPress Social Login is not properly configured.<br /> <b>%s</b> requires your application credentials.", 'wordpress-social-login'), $provider );
+			 $notes   = sprintf( _wsl__("<b>What does this error mean ?</b><br />Most likely, you didn't setup the correct application credentials for this provider. These credentials are required in order for <b>%s</b> users to access your website and for WordPress Social Login to work.", 'wordpress-social-login'), $provider ) . _wsl__('<br />Instructions for use can be found in the <a href="http://miled.github.io/wordpress-social-login/networks.html" target="_blank">User Manual</a>.', 'wordpress-social-login');
 			 break;
-		case 5 : $message = sprintf( _wsl__("Authentication failed. Either you have cancelled the authentication or <b>%s</b> refused the connection.", 'wordpress-social-login'), $provider ); break; 
+		case 5 : $message = sprintf( _wsl__("Authentication failed. Either you have cancelled the authentication or <b>%s</b> refused the connection.", 'wordpress-social-login'), $provider ); break;
 		case 6 : $message = sprintf( _wsl__("Request failed. Either you have cancelled the authentication or <b>%s</b> refused the connection.", 'wordpress-social-login'), $provider ); break;
 		case 7 : $message = _wsl__("You're not connected to the provider.", 'wordpress-social-login'); break;
 		case 8 : $message = _wsl__("Provider does not support this feature.", 'wordpress-social-login'); break;

--- a/includes/services/wsl.utilities.php
+++ b/includes/services/wsl.utilities.php
@@ -6,8 +6,8 @@
 *  (c) 2011-2014 Mohamed Mrassi and contributors | http://wordpress.org/plugins/wordpress-social-login/
 */
 
-/** 
-* Few utilities and functions 
+/**
+* Few utilities and functions
 */
 
 // Exit if accessed directly
@@ -30,7 +30,7 @@ function wsl_get_version()
 /**
 * Check if the current connection is being made over https
 *
-* Borrowed from http://wordpress.org/extend/plugins/oa-social-login/ 
+* Borrowed from http://wordpress.org/extend/plugins/oa-social-login/
 */
 function wsl_is_https_on()
 {
@@ -66,7 +66,7 @@ function wsl_is_https_on()
 /**
 * Return the current url
 *
-* Borrowed from http://wordpress.org/extend/plugins/oa-social-login/ 
+* Borrowed from http://wordpress.org/extend/plugins/oa-social-login/
 */
 function wsl_get_current_url()
 {
@@ -99,10 +99,10 @@ function wsl_get_current_url()
 	// overwrite all the above if ajax
 	if( strpos( $current_url, 'admin-ajax.php') && isset( $_SERVER ['HTTP_REFERER'] ) && $_SERVER ['HTTP_REFERER'] )
 	{
-		$current_url = $_SERVER ['HTTP_REFERER']; 
+		$current_url = $_SERVER ['HTTP_REFERER'];
 	}
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	$current_url = apply_filters( 'wsl_hook_alter_current_url', $current_url );
 
 	//Done
@@ -141,20 +141,20 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 	}
 	.wsl-dev-usedhook, .wsl-dev-usedhook a {
 		color: #1468fa;
-	} 
+	}
 	.wsl-dev-usedwslhook {
 		color: #a0a !important;
-	} 
+	}
 	.wsl-dev-unusedhook, .wsl-dev-unusedhook a{
 		color: #a3a3a3 !important;
 	}
 	.wsl-dev-hookcallback, .wsl-dev-hookcallback a {
 		color: #4a4 !important;
 	}
-	.wsl-dev-table { 
+	.wsl-dev-table {
 		width:100%;
 		border: 1px solid #e5e5e5;
-		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);	
+		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 		border-spacing: 0;
 		clear: both;
 		margin: 0;
@@ -162,7 +162,7 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 	}
 	.wsl-dev-table td, .wsl-dev-table th {
 		border: 1px solid #dddddd;
-		padding: 8px 10px; 
+		padding: 8px 10px;
 		background-color: #fff;
 		text-align: left;
 	}
@@ -177,7 +177,7 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 				<tr>
 					<td>
 						<?php echo Hybrid_Error::getApiError(); ?>
-					</td> 
+					</td>
 				</tr>
 			</table>
 		<?php
@@ -191,14 +191,14 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 				1. SAVEQUERIES should be defined and set to TRUE in order for the queries to show up (http://codex.wordpress.org/Editing_wp-config.php#Save_queries_for_analysis)
 				<br />
 				2. Calls for get_option() don't necessarily result on a query to the database. WP use both cache and wp_load_alloptions() to load all options at once. Hence, it won't be shown here.
-			</td> 
+			</td>
 		</tr>
 		<?php
-			$queries = $wpdb->queries; 
-			
+			$queries = $wpdb->queries;
+
 			$total_wsl_queries = 0;
 			$total_wsl_queries_time = 0;
-			
+
 			if( $queries )
 			{
 				foreach( $queries as $item )
@@ -206,7 +206,7 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 					$sql    = trim( $item[0] );
 					$time   = $item[1];
 					$stack  = $item[2];
-					
+
 					$sql = str_ireplace( array( ' FROM ', ' WHERE ' , ' LIMIT ' , ' GROUP BY ' , ' ORDER BY ' , ' SET ' ), ARRAY( "\n" . 'FROM ', "\n" . 'WHERE ', "\n" . 'LIMIT ', "\n" . 'GROUP BY ', "\n" . 'ORDER BY ', "\n" . 'SET ' ), $sql );
 
 					# https://wordpress.org/plugins/query-monitor/
@@ -247,8 +247,8 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 								</td>
 								<td valign="top" class="<?php if( ! stristr( '#' . $sql, '#select ' ) ) echo 'wsl-dev-nonselectsql'; ?>"><?php echo nl2br( $sql ); ?></td>
 								<td valign="top" width="50" nowrap class="<?php if( $time > 0.05 ) echo 'wsl-dev-expensivesql'; ?>"><?php echo number_format( $time, 4, '.', '' ); ?></td>
-							</tr>   
-						<?php 
+							</tr>
+						<?php
 
 						$total_wsl_queries++;
 						$total_wsl_queries_time += $time;
@@ -271,14 +271,14 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 				{
 					if ( isset( $wp_filter[$name] ) )
 					{
-						$action = $wp_filter[$name]; 
+						$action = $wp_filter[$name];
 
 						if( $action )
 						{
 							foreach( $action as $priority => $callbacks )
 							{
 								foreach( $callbacks as $callback )
-								{ 
+								{
 									if( isset( $callback['function'] ) && is_string( $callback['function'] ) )
 									{
 										if( stristr( $callback['function'], $keyword ) || stristr( $name, $keyword ) )
@@ -320,9 +320,9 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 														<?php echo $callback['accepted_args'] ; ?>
 													</td>
 												</tr>
-											<?php   
+											<?php
 										}
-									} 
+									}
 								}
 							}
 						}
@@ -338,12 +338,12 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 								<td></td>
 								<td></td>
 							</tr>
-						<?php   
+						<?php
 					}
 				}
 			}
 		?>
-	</table> 
+	</table>
 
 	<h4>PHP Session</h4>
 	<table class="wsl-dev-table">
@@ -351,7 +351,7 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 			foreach( $_SESSION as $k => $v )
 			{
 		?>
-			<tr><th width="270"><label><?php echo $k; ?></label></th><td><?php print_r( $v ); ?></td></tr>   
+			<tr><th width="270"><label><?php echo $k; ?></label></th><td><?php print_r( $v ); ?></td></tr>
 		<?php
 			}
 		?>
@@ -361,52 +361,53 @@ function wsl_display_dev_mode_debugging_area( $keyword = 'wsl_' )
 	<h4>Wordpress</h4>
 	<table class="wsl-dev-table">
 		<tbody>
-			<tr><th width="270"><label>Version</label></th><td><?php echo get_bloginfo( 'version' ); ?></td></tr>   
+			<tr><th width="270"><label>Version</label></th><td><?php echo get_bloginfo( 'version' ); ?></td></tr>
 			<tr><th><label>Multi-site</label></th><td><?php echo is_multisite() ? 'Yes' . "\n" : 'No'; ?></td></tr>
-			<tr><th><label>Site url</label></th><td><?php echo site_url(); ?></td></tr>   
-			<tr><th><label>Plugins url</label></th><td><?php echo plugins_url(); ?></td></tr>    
+			<tr><th><label>Site url</label></th><td><?php echo site_url(); ?></td></tr>
+			<tr><th><label>Home url</label></th><td><?php echo home_url(); ?></td></tr>
+			<tr><th><label>Plugins url</label></th><td><?php echo plugins_url(); ?></td></tr>
 		</tbody>
 	</table>
 
 	<h4>WSL</h4>
 	<table class="wsl-dev-table">
 		<tbody>
-			<tr><th width="270"><label>Version</label></th><td><?php echo wsl_get_version(); ?></td></tr>  
-			<tr><th><label>Plugin path</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_ABS_PATH; ?></td></tr>  
-			<tr><th><label>Plugin url</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL; ?></td></tr>  
-			<tr><th><label>HA endpoint</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL; ?></td></tr>   
+			<tr><th width="270"><label>Version</label></th><td><?php echo wsl_get_version(); ?></td></tr>
+			<tr><th><label>Plugin path</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_ABS_PATH; ?></td></tr>
+			<tr><th><label>Plugin url</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL; ?></td></tr>
+			<tr><th><label>HA endpoint</label></th><td><?php echo WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL; ?></td></tr>
 		</tbody>
-	</table>	
+	</table>
 
 	<h4>Website</h4>
 	<table class="wsl-dev-table">
 		<tbody>
-			<tr><th width="270"><label>IP</label></th><td><?php echo $_SERVER['SERVER_ADDR']; ?></td></tr>  
-			<tr><th><label>Domain</label></th><td><?php echo $_SERVER['HTTP_HOST']; ?></td></tr>  
-			<tr><th><label>Port</label></th><td><?php echo isset( $_SERVER['SERVER_PORT'] ) ? 'On (' . $_SERVER['SERVER_PORT'] . ')' : 'N/A'; ?></td></tr>  
-			<tr><th><label>X Forward</label></th><td><?php echo isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ? 'On (' . $_SERVER['HTTP_X_FORWARDED_PROTO'] . ')' : 'N/A';; ?></td></tr>   
+			<tr><th width="270"><label>IP</label></th><td><?php echo $_SERVER['SERVER_ADDR']; ?></td></tr>
+			<tr><th><label>Domain</label></th><td><?php echo $_SERVER['HTTP_HOST']; ?></td></tr>
+			<tr><th><label>Port</label></th><td><?php echo isset( $_SERVER['SERVER_PORT'] ) ? 'On (' . $_SERVER['SERVER_PORT'] . ')' : 'N/A'; ?></td></tr>
+			<tr><th><label>X Forward</label></th><td><?php echo isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ? 'On (' . $_SERVER['HTTP_X_FORWARDED_PROTO'] . ')' : 'N/A';; ?></td></tr>
 		</tbody>
 	</table>
-	
+
 	<h4>Software</h4>
 	<table class="wsl-dev-table">
 		<tbody>
-			<tr><th width="270"><label>Server</label></th><td><?php echo $_SERVER['SERVER_SOFTWARE']; ?></td></tr>  
-			<tr><th><label>PHP</label></th><td><?php echo PHP_VERSION; ?></td></tr>  
-			<tr><th><label>MySQL</label></th><td><?php echo $wpdb->db_version(); ?></td></tr>   
-			<tr><th><label>Time</label></th><td><?php echo date( DATE_ATOM, time() ); ?> / <?php echo time(); ?></td></tr>   
+			<tr><th width="270"><label>Server</label></th><td><?php echo $_SERVER['SERVER_SOFTWARE']; ?></td></tr>
+			<tr><th><label>PHP</label></th><td><?php echo PHP_VERSION; ?></td></tr>
+			<tr><th><label>MySQL</label></th><td><?php echo $wpdb->db_version(); ?></td></tr>
+			<tr><th><label>Time</label></th><td><?php echo date( DATE_ATOM, time() ); ?> / <?php echo time(); ?></td></tr>
 		</tbody>
 	</table>
 
 	<h4>MySQL</h4>
 	<table class="wsl-dev-table">
 		<tbody>
-			<tr><th width="270"><label>Host</label></th><td><?php echo $wpdb->dbhost; ?></td></tr>  
-			<tr><th><label>User</label></th><td><?php echo $wpdb->dbuser; ?></td></tr>  
-			<tr><th><label>Database</label></th><td><?php echo $wpdb->dbname; ?></td></tr>  
-			<tr><th><label>Prefix</label></th><td><?php echo $wpdb->prefix; ?></td></tr>  
-			<tr><th><label>Base_prefix</label></th><td><?php echo $wpdb->prefix; ?></td></tr>  
-			<tr><th><label>Num_queries</label></th><td><?php echo$wpdb->num_queries; ?></td></tr>  
+			<tr><th width="270"><label>Host</label></th><td><?php echo $wpdb->dbhost; ?></td></tr>
+			<tr><th><label>User</label></th><td><?php echo $wpdb->dbuser; ?></td></tr>
+			<tr><th><label>Database</label></th><td><?php echo $wpdb->dbname; ?></td></tr>
+			<tr><th><label>Prefix</label></th><td><?php echo $wpdb->prefix; ?></td></tr>
+			<tr><th><label>Base_prefix</label></th><td><?php echo $wpdb->prefix; ?></td></tr>
+			<tr><th><label>Num_queries</label></th><td><?php echo$wpdb->num_queries; ?></td></tr>
 		</tbody>
 	</table>
 <?php
@@ -430,7 +431,7 @@ function wsl_generate_backtrace()
     {
         $result[] = ( $i + 1 )  . ')' . str_ireplace( array( realpath( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/' ), realpath( WP_PLUGIN_DIR . '/' ), realpath( ABSPATH . '/' ) ) , '', substr( $trace[$i], strpos( $trace[$i], ' ' ) ) );
     }
-    
+
     return "\n\t" . implode( "\n\t", $result );
 }
 

--- a/includes/settings/wsl.compatibilities.php
+++ b/includes/settings/wsl.compatibilities.php
@@ -24,95 +24,95 @@ if ( !defined( 'ABSPATH' ) ) exit;
 // --------------------------------------------------------------------
 
 /**
-* Check and upgrade compatibilities from old WSL versions 
+* Check and upgrade compatibilities from old WSL versions
 */
 function wsl_update_compatibilities()
 {
 	delete_option( 'wsl_settings_development_mode_enabled' );
 	delete_option( 'wsl_settings_debug_mode_enabled' );
 
-	update_option( 'wsl_settings_welcome_panel_enabled', 1 ); 
+	update_option( 'wsl_settings_welcome_panel_enabled', 1 );
 
 	if( ! get_option( 'wsl_settings_redirect_url' ) )
-	{ 
-		update_option( 'wsl_settings_redirect_url', site_url() );
+	{
+		update_option( 'wsl_settings_redirect_url', home_url() );
 	}
 
 	if( ! get_option( 'wsl_settings_force_redirect_url' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_force_redirect_url', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_connect_with_label' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_connect_with_label', _wsl__("Connect with:", 'wordpress-social-login') );
 	}
 
 	if( ! get_option( 'wsl_settings_users_avatars' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_users_avatars', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_use_popup' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_use_popup', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_widget_display' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_widget_display', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_authentication_widget_css' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_authentication_widget_css', ".wp-social-login-connect-with {}\n.wp-social-login-provider-list {}\n.wp-social-login-provider-list a {}\n.wp-social-login-provider-list img {}\n.wsl_connect_with_provider {}" );
 	}
 
 	# bouncer settings
 	if( ! get_option( 'wsl_settings_bouncer_registration_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_registration_enabled', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_authentication_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_authentication_enabled', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_accounts_linking_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_accounts_linking_enabled', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_profile_completion_require_email' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_profile_completion_require_email', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_profile_completion_change_username' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_profile_completion_change_username', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_profile_completion_hook_extra_fields' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_profile_completion_hook_extra_fields', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_moderation_level' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_new_users_moderation_level', 1 );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_membership_default_role' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_new_users_membership_default_role', "default" );
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_restrict_domain_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_new_users_restrict_domain_enabled', 2 );
-	} 
+	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_restrict_domain_text_bounce' ) )
 	{
@@ -120,9 +120,9 @@ function wsl_update_compatibilities()
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_restrict_email_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_new_users_restrict_email_enabled', 2 );
-	} 
+	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_restrict_email_text_bounce' ) )
 	{
@@ -130,7 +130,7 @@ function wsl_update_compatibilities()
 	}
 
 	if( ! get_option( 'wsl_settings_bouncer_new_users_restrict_profile_enabled' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_bouncer_new_users_restrict_profile_enabled', 2 );
 	}
 
@@ -141,17 +141,17 @@ function wsl_update_compatibilities()
 
 	# contacts import
 	if( ! get_option( 'wsl_settings_contacts_import_facebook' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_contacts_import_facebook', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_contacts_import_google' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_contacts_import_google', 2 );
 	}
 
 	if( ! get_option( 'wsl_settings_contacts_import_twitter' ) )
-	{ 
+	{
 		update_option( 'wsl_settings_contacts_import_twitter', 2 );
 	}
 
@@ -178,11 +178,11 @@ function wsl_update_compatibilities()
 
 	# if no idp is enabled then we enable the default providers (facebook, google, twitter)
 	global $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG;
-	$nok = true; 
+	$nok = true;
 	foreach( $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG AS $item )
 	{
 		$provider_id = $item["provider_id"];
-		
+
 		if( get_option( 'wsl_settings_' . $provider_id . '_enabled' ) )
 		{
 			$nok = false;
@@ -197,9 +197,9 @@ function wsl_update_compatibilities()
 
 			if( isset( $item["default_network"] ) && $item["default_network"] ){
 				update_option( 'wsl_settings_' . $provider_id . '_enabled', 1 );
-			} 
-		} 
-	}	
+			}
+		}
+	}
 
 	global $wpdb;
 

--- a/includes/widgets/wsl.auth.widgets.php
+++ b/includes/widgets/wsl.auth.widgets.php
@@ -97,9 +97,9 @@ do_action( 'wsl_render_login_form_start' );
 		$social_icon_set = "wpzoom/";
 	}
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/32x32/' . $social_icon_set . '/'; 
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/32x32/' . $social_icon_set . '/';
 
-	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url; 
+	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url;
 
 	// HOOKABLE:
 	$assets_base_url = apply_filters( 'wsl_render_auth_widget_alter_assets_base_url', $assets_base_url );
@@ -115,19 +115,19 @@ do_action( 'wsl_render_login_form_start' );
 	// > admin auth playground
 	if( $auth_mode == 'test' )
 	{
-		$authenticate_base_url = site_url() . "/?action=wordpress_social_authenticate&mode=test&";
+		$authenticate_base_url = home_url() . "/?action=wordpress_social_authenticate&mode=test&";
 	}
 
 	// > account linking
 	elseif( $auth_mode == 'link' )
 	{
-		$authenticate_base_url = site_url() . "/?action=wordpress_social_authenticate&mode=link&";
+		$authenticate_base_url = home_url() . "/?action=wordpress_social_authenticate&mode=link&";
 	}
 
 	// Connect with caption
 	$connect_with_label = _wsl__( get_option( 'wsl_settings_connect_with_label' ), 'wordpress-social-login' );
 
-	$connect_with_label = isset( $args['caption'] ) ? $args['caption'] : $connect_with_label; 
+	$connect_with_label = isset( $args['caption'] ) ? $args['caption'] : $connect_with_label;
 
 	// HOOKABLE:
 	$connect_with_label = apply_filters( 'wsl_render_auth_widget_alter_connect_with_label', $connect_with_label );
@@ -138,7 +138,7 @@ do_action( 'wsl_render_login_form_start' );
 	WordPress Social Login <?php echo wsl_get_version(); ?>.
 	http://wordpress.org/plugins/wordpress-social-login/
 -->
-<?php 
+<?php
 	// Widget::Custom CSS
 	$widget_css = get_option( 'wsl_settings_authentication_widget_css' );
 
@@ -157,9 +157,9 @@ do_action( 'wsl_render_login_form_start' );
 			array( '%/\*(?:(?!\*/).)*\*/%s', '/\s{2,}/', "/\s*([;{}])[\r\n\t\s]/", '/\\s*;\\s*/', '/\\s*{\\s*/', '/;?\\s*}\\s*/' ),
 				array( '', ' ', '$1', ';', '{', '}' ),
 					$widget_css );
-?> 
+?>
 </style>
-<?php 
+<?php
 	}
 ?>
 
@@ -168,7 +168,7 @@ do_action( 'wsl_render_login_form_start' );
 	<div class="wp-social-login-connect-with"><?php echo $connect_with_label; ?></div>
 
 	<div class="wp-social-login-provider-list">
-<?php 
+<?php
 	// Widget::Authentication display
 	$wsl_settings_use_popup = get_option( 'wsl_settings_use_popup' );
 
@@ -206,7 +206,7 @@ do_action( 'wsl_render_login_form_start' );
 			// in case, Widget::Authentication display is set to 'popup', then we overwrite 'authenticate_url'
 			// > /assets/js/connect.js will take care of the rest
 			if( $wsl_settings_use_popup == 1 &&  $auth_mode != 'test' )
-			{ 
+			{
 				$authenticate_url= "javascript:void(0);";
 			}
 
@@ -217,7 +217,7 @@ do_action( 'wsl_render_login_form_start' );
 			$provider_icon_markup = apply_filters( 'wsl_render_auth_widget_alter_provider_icon_markup', $provider_id, $provider_name, $authenticate_url );
 
 // Depreciated and will be removed
-$provider_icon_markup = apply_filters( 'wsl_render_login_form_alter_provider_icon_markup', $provider_icon_markup, $provider_name, $authenticate_url ); 
+$provider_icon_markup = apply_filters( 'wsl_render_login_form_alter_provider_icon_markup', $provider_icon_markup, $provider_name, $authenticate_url );
 // Depreciated and will be removed
 
 			if( $provider_icon_markup != $provider_id )
@@ -232,12 +232,12 @@ $provider_icon_markup = apply_filters( 'wsl_render_login_form_alter_provider_ico
 			<?php if( $social_icon_set == 'none' ){ echo apply_filters( 'wsl_render_auth_widget_alter_provider_name', $provider_name ); } else { ?><img alt="<?php echo $provider_name ?>" title="<?php echo sprintf( _wsl__("Connect with %s", 'wordpress-social-login'), $provider_name ) ?>" src="<?php echo $assets_base_url . strtolower( $provider_id ) . '.png' ?>" /><?php } ?>
 
 		</a>
-<?php 
+<?php
 			}
 
-			$no_idp_used = false; 
-		} 
-	} 
+			$no_idp_used = false;
+		}
+	}
 
 	// no provider enabled?
 	if( $no_idp_used )
@@ -251,7 +251,7 @@ $provider_icon_markup = apply_filters( 'wsl_render_login_form_alter_provider_ico
 	}
 ?>
 
-	</div> 
+	</div>
 
 	<div class="wp-social-login-widget-clearing"></div>
 
@@ -266,7 +266,7 @@ $provider_icon_markup = apply_filters( 'wsl_render_login_form_alter_provider_ico
 <input type="hidden" id="wsl_login_form_uri" value="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" />
 
 <?php
-	} 
+	}
 
 	// HOOKABLE: This action runs just after generating the WSL Widget.
 	do_action( 'wsl_render_auth_widget_end' );
@@ -278,8 +278,8 @@ do_action( 'wsl_render_login_form_end' );
 <!-- wsl_render_auth_widget -->
 
 <?php
-	// Display WSL debugging area bellow the widget.  
-	// wsl_display_dev_mode_debugging_area(); // ! keep this line commented unless you know what you are doing :) 
+	// Display WSL debugging area bellow the widget.
+	// wsl_display_dev_mode_debugging_area(); // ! keep this line commented unless you know what you are doing :)
 
 	return ob_get_clean();
 }
@@ -287,7 +287,7 @@ do_action( 'wsl_render_login_form_end' );
 // --------------------------------------------------------------------
 
 /**
-* WSL wordpress_social_login action 
+* WSL wordpress_social_login action
 *
 * Ref: http://codex.wordpress.org/Function_Reference/add_action
 */
@@ -370,9 +370,9 @@ function wsl_shortcode_wordpress_social_login_meta( $args = array() )
 		return;
 	}
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/'; 
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
 
-	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url; 
+	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url;
 
 	$return = '';
 
@@ -391,7 +391,7 @@ function wsl_shortcode_wordpress_social_login_meta( $args = array() )
 	if( 'current_provider' == $meta )
 	{
 		$provider = get_user_meta( $user_id, 'wsl_current_provider', true );
-		
+
 		if( 'plain' == $display )
 		{
 			$return = $provider;
@@ -413,7 +413,7 @@ function wsl_shortcode_wordpress_social_login_meta( $args = array() )
 			?><table class="wp-social-login-linked-accounts-list <?php echo $css_class; ?>"><?php
 
 			foreach( $linked_accounts AS $item )
-			{  
+			{
 				$identity = $item->profileurl;
 				$photourl = $item->photourl;
 
@@ -421,9 +421,9 @@ function wsl_shortcode_wordpress_social_login_meta( $args = array() )
 				{
 					$identity = $item->identifier;
 				}
-				
-				?><tr><td><?php if( $photourl ) { ?><img  style="vertical-align: top;width:16px;height:16px;" src="<?php echo $photourl ?>"> <?php } else { ?><img src="<?php echo $assets_base_url . strtolower(  $item->provider ) . '.png' ?>" /> <?php } ?><?php echo ucfirst( $item->provider ); ?> </td><td><?php echo $identity; ?></td></tr><?php 
-				
+
+				?><tr><td><?php if( $photourl ) { ?><img  style="vertical-align: top;width:16px;height:16px;" src="<?php echo $photourl ?>"> <?php } else { ?><img src="<?php echo $assets_base_url . strtolower(  $item->provider ) . '.png' ?>" /> <?php } ?><?php echo ucfirst( $item->provider ); ?> </td><td><?php echo $identity; ?></td></tr><?php
+
 				echo "\n";
 			}
 
@@ -454,12 +454,12 @@ function wsl_render_auth_widget_in_comment_form()
 
 	if( comments_open() )
 	{
-		if( 
+		if(
 			!  $wsl_settings_widget_display
-		|| 
-			$wsl_settings_widget_display == 1 
-		|| 
-			$wsl_settings_widget_display == 2 
+		||
+			$wsl_settings_widget_display == 1
+		||
+			$wsl_settings_widget_display == 2
 		)
 		{
 			echo wsl_render_auth_widget();
@@ -478,7 +478,7 @@ add_action( 'comment_form_must_log_in_after', 'wsl_render_auth_widget_in_comment
 function wsl_render_auth_widget_in_wp_login_form()
 {
 	$wsl_settings_widget_display = get_option( 'wsl_settings_widget_display' );
-	
+
 	if( $wsl_settings_widget_display == 1 || $wsl_settings_widget_display == 3 )
 	{
 		echo wsl_render_auth_widget();
@@ -516,13 +516,13 @@ function wsl_add_stylesheets()
 {
 	if( ! wp_style_is( 'wsl-widget', 'registered' ) )
 	{
-		wp_register_style( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "/assets/css/style.css" ); 
+		wp_register_style( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "/assets/css/style.css" );
 	}
 
-	wp_enqueue_style( "wsl-widget" ); 
+	wp_enqueue_style( "wsl-widget" );
 }
 
-add_action( 'wp_enqueue_scripts'   , 'wsl_add_stylesheets' ); 
+add_action( 'wp_enqueue_scripts'   , 'wsl_add_stylesheets' );
 add_action( 'login_enqueue_scripts', 'wsl_add_stylesheets' );
 
 // --------------------------------------------------------------------
@@ -546,7 +546,7 @@ function wsl_add_javascripts()
 	wp_enqueue_script( "wsl-widget" );
 }
 
-add_action( 'wp_enqueue_scripts'   , 'wsl_add_javascripts' ); 
+add_action( 'wp_enqueue_scripts'   , 'wsl_add_javascripts' );
 add_action( 'login_enqueue_scripts', 'wsl_add_javascripts' );
 
 // --------------------------------------------------------------------

--- a/includes/widgets/wsl.error.pages.php
+++ b/includes/widgets/wsl.error.pages.php
@@ -20,9 +20,9 @@ if( !defined( 'ABSPATH' ) ) exit;
 *
 * This function is mainly used by bouncer
 *
-* Note: 
+* Note:
 *   In case you want to customize the content generated, you may redefine this function
-*   Just make sure the script DIES at the end. 
+*   Just make sure the script DIES at the end.
 *
 *   The $message to display for users is passed as a parameter.
 */
@@ -30,7 +30,7 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 {
 	function wsl_render_notice_page( $message )
 	{
-		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>
@@ -85,9 +85,9 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 				margin-top:25px;
 			}
 		</style>
-	<head>  
+	<head>
 	<body>
-		<div id="notice-page"> 
+		<div id="notice-page">
 			<table width="100%" border="0">
 				<tr>
 					<td align="center"><img src="<?php echo $assets_base_url ?>alert.png" /></td>
@@ -95,14 +95,14 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 				<tr>
 					<td align="center">
 						<div class="notice-message">
-							<?php echo nl2br( $message ); ?> 
+							<?php echo nl2br( $message ); ?>
 						</div>
-					</td> 
-				</tr> 
+					</td>
+				</tr>
 			</table>
 		</div>
 
-		<?php 
+		<?php
 			// Development mode on?
 			if( get_option( 'wsl_settings_development_mode_enabled' ) )
 			{
@@ -110,7 +110,7 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 			}
 		?>
 	</body>
-</html> 
+</html>
 <?php
 		die();
 	}
@@ -120,14 +120,14 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 
 /**
 * Display an error page to the user and kill WordPress execution
-* 
+*
 * This function differ than wsl_render_notice_page as it have some extra parameters and also should allow debugging
 *
 * This function is used when WSL fails to authenticated a user with social networks
-* 
-* Note: 
+*
+* Note:
 *   In case you want to customize the content generated, you may redefine this function
-*   Just make sure the script DIES at the end. 
+*   Just make sure the script DIES at the end.
 *
 *   The $message to display for users is passed as a parameter and it's required.
 */
@@ -135,7 +135,7 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 {
 	function wsl_render_error_page( $message, $notes = null, $provider = null, $api_error = null, $php_exception = null )
 	{
-		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>
@@ -144,8 +144,8 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 		<title><?php bloginfo('name'); ?> - <?php _wsl_e("Oops! We ran into an issue", 'wordpress-social-login') ?>.</title>
 		<style type="text/css">
 			body {
-				background: #f1f1f1;			
-			} 
+				background: #f1f1f1;
+			}
 			h4 {
 				color: #666;
 				font: 20px "Open Sans", sans-serif;
@@ -157,7 +157,7 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 				font-size: 14px;
 				line-height: 1.5;
 				margin: 15px 0;
-				line-height: 25px; 
+				line-height: 25px;
 				padding: 10px;
 				text-align:left;
 			}
@@ -197,9 +197,9 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 				box-shadow: 0 1px 3px rgba(0,0,0,0.13);
 				margin-top:25px;
 			}
-			.error-hint{ 
+			.error-hint{
 				margin:0;
-			} 
+			}
 			#debuginfo {
 				display:none;
 				text-align: center;
@@ -222,13 +222,13 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 				</tr>
 
 				<tr>
-					<td align="center"><h4><?php _wsl_e("Oops! We ran into an issue", 'wordpress-social-login') ?>.</h4></td> 
+					<td align="center"><h4><?php _wsl_e("Oops! We ran into an issue", 'wordpress-social-login') ?>.</h4></td>
 				</tr>
 
 				<tr>
 					<td>
 						<div class="error-message">
-							<?php echo $message ; ?> 
+							<?php echo $message ; ?>
 						</div>
 
 						<?php
@@ -240,33 +240,33 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 								<?php
 							}
 						?>
-					</td> 
-				</tr> 
+					</td>
+				</tr>
 
 				<tr>
 					<td>
-						<p style="padding: 0;"> 
+						<p style="padding: 0;">
 							<a href="javascript:xi();" style="float:right"><?php _wsl_e("Details", 'wordpress-social-login') ?></a>
-							<a href="<?php echo site_url(); ?>" style="float:left">&xlarr; <?php _wsl_e("Back to home", 'wordpress-social-login') ?></a>
+							<a href="<?php echo home_url(); ?>" style="float:left">&xlarr; <?php _wsl_e("Back to home", 'wordpress-social-login') ?></a>
 						</p>
-						
+
 						<br style="clear:both;" />
 
 						<p id="debuginfo">&xi; <?php echo $api_error ?></p>
-					</td> 
-				</tr> 
+					</td>
+				</tr>
 			</table>
-		</div> 
+		</div>
 
-		<?php 
+		<?php
 			// Development mode on?
 			if( get_option( 'wsl_settings_development_mode_enabled' ) )
 			{
 				wsl_render_error_page_debug_section( $php_exception );
 			}
-		?> 
+		?>
 	</body>
-</html> 
+</html>
 <?php
 	# keep these 2 LOC
 		do_action( 'wsl_clear_user_php_session' );

--- a/includes/widgets/wsl.users.gateway.php
+++ b/includes/widgets/wsl.users.gateway.php
@@ -10,7 +10,7 @@
 * New Users Gateway: Accounts linking + Profile Completion
 *
 * When enabled, Bouncer will popup this screen for unrecognised user, where they will be given the choice to either associate
-* any existing account in your website with the provider ID they have connected with or to create a new user account. 
+* any existing account in your website with the provider ID they have connected with or to create a new user account.
 *
 * Note:
 * 	1. This is not implemented yet. It still a proof of concept and planned for WSL 2.3.
@@ -32,7 +32,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 	// remove wsl widget
 	remove_action( 'register_form', 'wsl_render_auth_widget_in_wp_register_form' );
 
-	$hybridauth_user_email       = sanitize_email( $hybridauth_user_profile->email ); 
+	$hybridauth_user_email       = sanitize_email( $hybridauth_user_profile->email );
 	$hybridauth_user_login       = sanitize_user( $hybridauth_user_profile->displayName, true );
 	$hybridauth_user_avatar      = $hybridauth_user_profile->photoURL;
 	$hybridauth_user_website     = $hybridauth_user_profile->webSiteURL;
@@ -47,18 +47,18 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 	$requested_user_email        = apply_filters( 'wsl_new_users_gateway_alter_requested_email', $requested_user_email );
 	$requested_user_login        = apply_filters( 'wsl_new_users_gateway_alter_requested_login', $requested_user_login );
 
-	$user_id    = 0; 
-	$shall_pass = false; 
+	$user_id    = 0;
+	$shall_pass = false;
 
-	$bouncer_account_linking    = false; 
-	$account_linking_errors     = array(); 
+	$bouncer_account_linking    = false;
+	$account_linking_errors     = array();
 
-	$bouncer_profile_completion = false; 
-	$profile_completion_errors  = array(); 
+	$bouncer_profile_completion = false;
+	$profile_completion_errors  = array();
 
 	$linking_enabled = get_option( 'wsl_settings_bouncer_accounts_linking_enabled' );
 
-	// $linking_enabled = 2; // overide linking_enabled  
+	// $linking_enabled = 2; // overide linking_enabled
 
 	if( isset( $_REQUEST["bouncer_account_linking"] ) )
 	{
@@ -67,7 +67,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 			return wsl_process_login_render_notice_page( _wsl__( "Not tonight.", 'wordpress-social-login' ) );
 		}
 
-		$bouncer_account_linking = true; 
+		$bouncer_account_linking = true;
 
 		$username = isset( $_REQUEST["user_login"]    ) ? trim( $_REQUEST["user_login"]    ) : '';
 		$password = isset( $_REQUEST["user_password"] ) ? trim( $_REQUEST["user_password"] ) : '';
@@ -106,7 +106,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 		// otherwise we request email &or username &or extra fields
 		else
 		{
-			$bouncer_profile_completion = true; 
+			$bouncer_profile_completion = true;
 
 			/**
 			* Code based on wpmu_validate_user_signup()
@@ -189,7 +189,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 
 			$profile_completion_errors = apply_filters( 'wsl_new_users_gateway_alter_profile_completion_errors', $profile_completion_errors );
 
-			// all check? 
+			// all check?
 			if( ! $profile_completion_errors )
 			{
 				$shall_pass = true;
@@ -199,12 +199,12 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 
 	if( $shall_pass == false )
 	{
-?> 
+?>
 <!DOCTYPE html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title><?php echo get_bloginfo('name'); ?></title>
-		<style type="text/css"> 
+		<style type="text/css">
 			html, body {
 				height: 100%;
 				margin: 0;
@@ -226,7 +226,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 				font-size: 14px;
 				margin-bottom: 10px;
 			}
-			#login { 
+			#login {
 				width: 616px;
 				margin: auto;
 				padding: 114px 0 0;
@@ -330,7 +330,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 			}
 			table {
 				width:355px;
-				margin-left:auto; 
+				margin-left:auto;
 				margin-right:auto;
 			}
 			#mapping-options {
@@ -348,7 +348,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 				border-left: 4px solid #dd3d36;
 				box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 				margin: 0 21px;
-				padding: 12px;	
+				padding: 12px;
 				text-align:left;
 			}
 			.back-to-options {
@@ -414,7 +414,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 
 				toggleEl( 'welcome'        , 'block' );
 				toggleEl( 'mapping-options', 'block' );
-				
+
 				toggleEl( 'errors-profile-completion', 'none' );
 				toggleEl( 'mapping-authenticate'     , 'none' );
 
@@ -429,7 +429,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 				toggleEl( 'welcome'        , 'none' );
 				toggleEl( 'mapping-options', 'none' );
 
-				toggleEl( 'errors-account-linking', 'block' ); 
+				toggleEl( 'errors-account-linking', 'block' );
 				toggleEl( 'mapping-authenticate'  , 'block' );
 
 				toggleEl( 'errors-profile-completion', 'none' );
@@ -459,7 +459,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 				</div>
 
 				<div id="welcome">
-					<img id="idp-icon" src="<?php echo $assets_base_url . strtolower($provider); ?>.png" > 
+					<img id="idp-icon" src="<?php echo $assets_base_url . strtolower($provider); ?>.png" >
 					<b><?php printf( _wsl__( "Hi %s", 'wordpress-social-login' ), htmlentities( $hybridauth_user_profile->displayName ) ); ?></b>
 					<p><?php printf( _wsl__( "You're now signed in with your %s account but you are still one step away of getting into our website", 'wordpress-social-login' ), $provider ); ?>.</p>
 
@@ -479,22 +479,22 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 							<p style="font-size: 12px;"><?php printf( _wsl__( "Create a new account and it will be associated with your %s ID.", 'wordpress-social-login' ), $provider ); ?></p>
 						</td>
 					</tr>
-					
+
 					<tr>
 						<?php if( $linking_enabled == 1 ): ?>
 							<td valign="top"  width="50%" style="text-align:center;">
-								<input type="button" value="<?php _wsl_e( "Link my account", 'wordpress-social-login' ); ?>" class="button-primary" onclick="display_mapping_authenticate();" > 
+								<input type="button" value="<?php _wsl_e( "Link my account", 'wordpress-social-login' ); ?>" class="button-primary" onclick="display_mapping_authenticate();" >
 							</td>
 						<?php endif; ?>
 						<td valign="top"  width="50%" style="text-align:center;">
-							<input type="button" value="<?php _wsl_e( "Create a new account", 'wordpress-social-login' ); ?>" class="button-primary" onclick="display_mapping_complete_info();" > 
+							<input type="button" value="<?php _wsl_e( "Create a new account", 'wordpress-social-login' ); ?>" class="button-primary" onclick="display_mapping_complete_info();" >
 						</td>
 					</tr>
-				</table> 
+				</table>
 
 				<?php
 					if( $account_linking_errors )
-					{ 
+					{
 						echo '<div id="errors-account-linking" class="error">';
 
 						foreach( $account_linking_errors as $error )
@@ -506,7 +506,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 					}
 
 					if( $profile_completion_errors )
-					{ 
+					{
 						echo '<div id="errors-profile-completion" class="error">';
 
 						foreach( $profile_completion_errors as $error )
@@ -515,18 +515,18 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 						}
 
 						echo '</div>';
-					} 
+					}
 				?>
 
 				<form method="post" action="<?php echo site_url( 'wp-login.php', 'login_post' ); ?>" id="login-form">
-					<table id="mapping-authenticate" border="0"> 
+					<table id="mapping-authenticate" border="0">
 						<tr>
 							<td valign="top"  width="50%" style="text-align:center;">
-								<h4><?php _wsl_e( "Already have an account", 'wordpress-social-login' ); ?>?</h4> 
+								<h4><?php _wsl_e( "Already have an account", 'wordpress-social-login' ); ?>?</h4>
 
 								<p><?php printf( _wsl__( "Please enter your username and password of your existing account on our website. Once verified, it will linked to your % ID", 'wordpress-social-login' ), ucfirst( $provider ) ) ; ?>.</p>
 							</td>
-						</tr> 
+						</tr>
 						<tr>
 							<td valign="bottom"  width="50%" style="text-align:left;">
 								<label>
@@ -539,22 +539,22 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 									<?php _wsl_e( "Password", 'wordpress-social-login' ); ?>
 									<br />
 									<input type="text" name="user_password" class="input" value="" size="25" placeholder="" />
-								</label> 
+								</label>
 
-								<input type="submit" value="<?php _wsl_e( "Continue", 'wordpress-social-login' ); ?>" class="button-primary" > 
-								
+								<input type="submit" value="<?php _wsl_e( "Continue", 'wordpress-social-login' ); ?>" class="button-primary" >
+
 								<a href="javascript:void(0);" onclick="display_mapping_options();" class="back-to-options"><?php _wsl_e( "Back", 'wordpress-social-login' ); ?></a>
 							</td>
 						</tr>
-					</table> 
+					</table>
 
-					<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo $redirect_to ?>"> 
-					<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>"> 
+					<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo $redirect_to ?>">
+					<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>">
 					<input type="hidden" id="action" name="action" value="wordpress_social_account_linking">
 					<input type="hidden" id="bouncer_account_linking" name="bouncer_account_linking" value="1">
 				</form>
 
-				<form method="post" action="<?php echo site_url( 'wp-login.php', 'login_post' ); ?>" id="login-form"> 
+				<form method="post" action="<?php echo site_url( 'wp-login.php', 'login_post' ); ?>" id="login-form">
 					<table id="mapping-complete-info" border="0">
 						<tr>
 							<td valign="top"  width="50%" style="text-align:center;">
@@ -577,7 +577,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 									<?php _wsl_e( "E-mail", 'wordpress-social-login' ); ?>
 									<br />
 									<input type="text" name="user_email" class="input" value="<?php echo $requested_user_email; ?>" size="25" placeholder="" />
-								</label> 
+								</label>
 
 								<?php
 									/**
@@ -595,34 +595,34 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 									}
 								?>
 
-								<input type="submit" value="<?php _wsl_e( "Continue", 'wordpress-social-login' ); ?>" class="button-primary" > 
+								<input type="submit" value="<?php _wsl_e( "Continue", 'wordpress-social-login' ); ?>" class="button-primary" >
 
 								<?php if( $linking_enabled == 1 ): ?>
 									<a href="javascript:void(0);" onclick="display_mapping_options();" class="back-to-options"><?php _wsl_e( "Back", 'wordpress-social-login' ); ?></a>
 								<?php endif; ?>
 							</td>
 						</tr>
-					</table> 
+					</table>
 
-					<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo $redirect_to ?>"> 
-					<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>"> 
+					<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo $redirect_to ?>">
+					<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>">
 					<input type="hidden" id="action" name="action" value="wordpress_social_account_linking">
 					<input type="hidden" id="bouncer_profile_completion" name="bouncer_profile_completion" value="1">
 				</form>
 			</div>
 
 			<p class="back-to-home">
-				<a href="<?php echo site_url(); ?>">&#8592; <?php printf( _wsl__( "Back to %s", 'wordpress-social-login' ), get_bloginfo('name') ); ?></a>
+				<a href="<?php echo home_url(); ?>">&#8592; <?php printf( _wsl__( "Back to %s", 'wordpress-social-login' ), get_bloginfo('name') ); ?></a>
 			</p>
 		</div>
 
-		<?php 
+		<?php
 			// Development mode on?
 			if( get_option( 'wsl_settings_development_mode_enabled' ) )
 			{
 				wsl_display_dev_mode_debugging_area();
 			}
-		?> 
+		?>
 	</body>
 </html>
 <?php

--- a/tests/test_install.php
+++ b/tests/test_install.php
@@ -37,7 +37,7 @@ class WSL_Test_Install extends WP_UnitTestCase
 	function test_options_created()
 	{
 		$test = get_option( 'wsl_settings_redirect_url' );
-		$this->assertEquals( site_url(), $test );
+		$this->assertEquals( home_url(), $test );
 
 		$test = get_option( 'wsl_settings_buddypress_xprofile_map' );
 		$this->assertEquals( '', $test );


### PR DESCRIPTION
WordPress sometimes resides in its [own directory](https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory). For example, see [this](https://github.com/ihorvorotnov/CDBS) and [this](https://github.com/markjaquith/WordPress-Skeleton) skeleton repos. In this case `site_url()` returns wrong URL - `http://example.com/custom_wp_dir`. When you pass `wp-login.php` to the `site_url()` function - it's absolutely correct, but site's frontend should be reached via `home_url()` which points to the root of your custom install. 

I've replace some occurences of `site_url()` with `home_url()` and added `home_url()` output to debug info. Tested on my local install, haven't found any bugs, but it would be nice if you check the code and see if I haven't edited smth that shouldn't be.

Some other thoughts on custom setups (which are pretty common and totally allowed by WP):

- for WordPress Multisite there's another trick with `network_site_url()`, `network_home_url()`. I'll have a chance to test WSL on WP MS next week, will test everything and see if we need another PR
- some plugins (and custom developed code) are changing the login url via hooks, for example, preventing access to `wp-login.php` and forwarding requests to `/login/` or `/signon/`. That pages can be the original `wp-login.php` or custom pages with login form via `wp_login_form()` [function](https://codex.wordpress.org/Function_Reference/wp_login_form). See [login_url](https://codex.wordpress.org/Plugin_API/Filter_Reference/login_url), [register_url](https://codex.wordpress.org/Plugin_API/Filter_Reference/register_url) for details.

Will be happy to help making it work with that custom setups as I use them on most of the sites.

Oh, @miled, did I mention that you plugin is crazy awesome? White-labeling and having no API request limits is great! And the code is total pleasure to read :+1: 
