### PR TITLE
Remove hardcoded plugin dir

### DIFF
--- a/includes/admin/components/auth-paly/index.php
+++ b/includes/admin/components/auth-paly/index.php
@@ -11,7 +11,7 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 /*!
 	Important
@@ -23,23 +23,23 @@ if ( !defined( 'ABSPATH' ) ) exit;
 
 function wsl_component_authtest()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_authtest_start" );
 
 	$adapter      = null;
 	$provider_id  = isset( $_REQUEST["provider"] ) ? $_REQUEST["provider"] : null;
 	$user_profile = null;
-	
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
+
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 
 	if( ! class_exists( 'Hybrid_Auth', false ) )
 	{
-		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "/hybridauth/Hybrid/Auth.php";
+		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "hybridauth/Hybrid/Auth.php";
 	}
 
 	try
 	{
-		$provider = Hybrid_Auth::getAdapter( $provider_id ); 
+		$provider = Hybrid_Auth::getAdapter( $provider_id );
 
 		// make as few call as possible
 		if( ! ( isset( $_SESSION['wsl::userprofile'] ) && $_SESSION['wsl::userprofile'] && $user_profile = json_decode( $_SESSION['wsl::userprofile'] ) ) )
@@ -69,7 +69,7 @@ function wsl_component_authtest()
 		array( 'field' => 'age'         , 'label' => _wsl__( "Age"              , 'wordpress-social-login') ),
 		array( 'field' => 'birthDay'    , 'label' => _wsl__( "Birth day"        , 'wordpress-social-login') ),
 		array( 'field' => 'birthMonth'  , 'label' => _wsl__( "Birth month"      , 'wordpress-social-login') ),
-		array( 'field' => 'birthYear'   , 'label' => _wsl__( "Birth year"       , 'wordpress-social-login') ), 
+		array( 'field' => 'birthYear'   , 'label' => _wsl__( "Birth year"       , 'wordpress-social-login') ),
 		array( 'field' => 'email'       , 'label' => _wsl__( "Email"            , 'wordpress-social-login') ),
 		array( 'field' => 'phone'       , 'label' => _wsl__( "Phone"            , 'wordpress-social-login') ),
 		array( 'field' => 'address'     , 'label' => _wsl__( "Address"          , 'wordpress-social-login') ),
@@ -77,7 +77,7 @@ function wsl_component_authtest()
 		array( 'field' => 'region'      , 'label' => _wsl__( "Region"           , 'wordpress-social-login') ),
 		array( 'field' => 'city'        , 'label' => _wsl__( "City"             , 'wordpress-social-login') ),
 		array( 'field' => 'zip'         , 'label' => _wsl__( "Zip"              , 'wordpress-social-login') ),
-	);	
+	);
 ?>
 <style>
 	.widefat td, .widefat th { border: 1px solid #DDDDDD; }
@@ -89,7 +89,7 @@ function wsl_component_authtest()
 </style>
 
 <div class="metabox-holder columns-2" id="post-body">
-	<table width="100%"> 
+	<table width="100%">
 		<tr valign="top">
 			<td>
 				<?php if( ! $adapter ): ?>
@@ -101,20 +101,20 @@ function wsl_component_authtest()
 						<h3>
 							<label><?php _wsl_e("Connected adapter specs", 'wordpress-social-login') ?></label>
 						</h3>
-						<div class="inside"> 
+						<div class="inside">
 							<table class="wp-list-table widefat">
 								<tr>
 									<th width="200"><label><?php _wsl_e("Provider", 'wordpress-social-login') ?></label></th>
 									<td><?php echo $adapter->providerId; ?></td>
 								</tr>
-								
+
 								<?php if( isset( $adapter->openidIdentifier ) ): ?>
 									<tr>
 										<th width="200"><label><?php _wsl_e("OpenID Identifier", 'wordpress-social-login') ?></label></th>
 										<td><?php echo $adapter->openidIdentifier; ?></td>
 									</tr>
 								<?php endif; ?>
-								
+
 								<?php if( isset( $adapter->scope ) ): ?>
 									<tr>
 										<th width="200"><label><?php _wsl_e("Scope", 'wordpress-social-login') ?></label></th>
@@ -161,7 +161,7 @@ function wsl_component_authtest()
 					</div>
 
 					<?php
-						$console = false; 
+						$console = false;
 
 						if( ! isset( $adapter->openidIdentifier ) ):
 					?>
@@ -169,12 +169,12 @@ function wsl_component_authtest()
 							<h3>
 								<label><?php _wsl_e("Connected adapter console", 'wordpress-social-login') ?></label>
 							</h3>
-							<div class="inside"> 
+							<div class="inside">
 								<?php
-									$path   = isset( $adapter->api->api_base_url ) ? $adapter->api->api_base_url : ''; 
-									$path   = isset( $_REQUEST['console-path']   ) ? $_REQUEST['console-path']   : $path; 
-									$method = isset( $_REQUEST['console-method'] ) ? $_REQUEST['console-method'] : ''; 
-									$query  = isset( $_REQUEST['console-query']  ) ? $_REQUEST['console-query']  : ''; 
+									$path   = isset( $adapter->api->api_base_url ) ? $adapter->api->api_base_url : '';
+									$path   = isset( $_REQUEST['console-path']   ) ? $_REQUEST['console-path']   : $path;
+									$method = isset( $_REQUEST['console-method'] ) ? $_REQUEST['console-method'] : '';
+									$query  = isset( $_REQUEST['console-query']  ) ? $_REQUEST['console-query']  : '';
 
 									$response = '';
 
@@ -216,20 +216,20 @@ function wsl_component_authtest()
 											<td><textarea style="width:100%;height:60px;margin-top:6px;" name="console-query"><?php echo htmlentities( $query ); ?></textarea></td>
 										</tr>
 									</table>
-									
+
 									<br />
 
 									<input type="submit" value="<?php _wsl_e("Submit", 'wordpress-social-login') ?>" class="button">
 								</form>
 							</div>
 						</div>
-						
+
 						<?php if( $console ): ?>
 							<div class="stuffbox">
 								<h3>
 									<label><?php _wsl_e("API Response", 'wordpress-social-login') ?></label>
 								</h3>
-								<div class="inside"> 
+								<div class="inside">
 									<textarea rows="25" cols="70" wrap="off" style="width:100%;height:400px;margin-bottom:15px;font-family: monospace;font-size: 12px;"><?php echo htmlentities( print_r( $response, true ) ); ?></textarea>
 								</div>
 							</div>
@@ -238,9 +238,9 @@ function wsl_component_authtest()
 								<h3>
 									<label><?php _wsl_e("Code PHP", 'wordpress-social-login') ?></label>
 								</h3>
-								<div class="inside"> 
+								<div class="inside">
 <textarea rows="25" cols="70" wrap="off" style="width:100%;height:210px;margin-bottom:15px;font-family: monospace;font-size: 12px;"
->include_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/hybridauth/Hybrid/Auth.php';
+>include_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'hybridauth/Hybrid/Auth.php';
 
 /*!
 	Important
@@ -250,7 +250,7 @@ function wsl_component_authtest()
 
 try
 {
-    $<?php echo strtolower( $adapter->providerId ); ?> = Hybrid_Auth::getAdapter( '<?php echo htmlentities( $provider_id ); ?>' ); 
+    $<?php echo strtolower( $adapter->providerId ); ?> = Hybrid_Auth::getAdapter( '<?php echo htmlentities( $provider_id ); ?>' );
 
 <?php if( $method == 'GET' ): ?>
     $response = $<?php echo strtolower( $adapter->providerId ); ?>->api()->get( '<?php echo htmlentities( $path . ( $query ? '?' . $query : '' ) ); ?>' );
@@ -289,7 +289,7 @@ catch( Exception $e )
 							<h3>
 								<label><?php _wsl_e("Connected user social profile", 'wordpress-social-login') ?></label>
 							</h3>
-							<div class="inside"> 
+							<div class="inside">
 								<table class="wp-list-table widefat">
 									<?php
 										$user_profile = (array) $user_profile;
@@ -322,12 +322,12 @@ catch( Exception $e )
 															}
 															else
 															{
-																echo $field_value; 
+																echo $field_value;
 															}
 														}
 													?>
 												</td>
-											</tr> 
+											</tr>
 										<?php
 										}
 									?>
@@ -350,30 +350,30 @@ catch( Exception $e )
 							<p>
 								<?php _wsl_e('This tool will also give you a direct access to social networks apis via a lightweight console', 'wordpress-social-login') ?>.
 							</p>
-						</div> 
-					</div> 
-				</div> 
+						</div>
+					</div>
+				</div>
 
 				</style>
 				<div class="postbox">
 					<div class="inside">
 						<div style="padding:0 20px;">
 							<p>
-								<?php _wsl_e("Connect with", 'wordpress-social-login') ?>: 
+								<?php _wsl_e("Connect with", 'wordpress-social-login') ?>:
 							</p>
 
 							<div style="width: 380px; padding: 10px; border: 1px solid #ddd; background-color: #fff;">
-								<?php do_action( 'wordpress_social_login', array( 'mode' => 'test', 'caption' => '' ) ); ?> 
-							</div> 
+								<?php do_action( 'wordpress_social_login', array( 'mode' => 'test', 'caption' => '' ) ); ?>
+							</div>
 						</div>
-					</div> 
+					</div>
 				</div>
 			</td>
 		</tr>
 	</table>
-</div> 
-<?php	
-	// HOOKABLE: 
+</div>
+<?php
+	// HOOKABLE:
 	do_action( "wsl_component_authtest_end" );
 }
 

--- a/includes/admin/components/buddypress/wsl.components.buddypress.setup.php
+++ b/includes/admin/components/buddypress/wsl.components.buddypress.setup.php
@@ -11,7 +11,7 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
@@ -19,7 +19,7 @@ function wsl_component_buddypress_setup()
 {
 	$sections = array(
 		'user_avatar'     => 'wsl_component_buddypress_setup_user_avatar',
-		'profile_mapping' => 'wsl_component_buddypress_setup_profile_mapping', 
+		'profile_mapping' => 'wsl_component_buddypress_setup_profile_mapping',
 	);
 
 	$sections = apply_filters( 'wsl_component_buddypress_setup_alter_sections', $sections );
@@ -27,24 +27,24 @@ function wsl_component_buddypress_setup()
 	foreach( $sections as $section => $action )
 	{
 		add_action( 'wsl_component_buddypress_setup_sections', $action );
-	}	
+	}
 ?>
 <div>
 	<?php
-		// HOOKABLE: 
+		// HOOKABLE:
 		do_action( 'wsl_component_buddypress_setup_sections' );
 	?>
 
 	<br />
 
-	<div style="margin-left:5px;margin-top:-20px;"> 
-		<input type="submit" class="button-primary" value="<?php _wsl_e("Save Settings", 'wordpress-social-login') ?>" /> 
+	<div style="margin-left:5px;margin-top:-20px;">
+		<input type="submit" class="button-primary" value="<?php _wsl_e("Save Settings", 'wordpress-social-login') ?>" />
 	</div>
 </div>
 <?php
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_buddypress_setup_user_avatar()
 {
@@ -53,9 +53,9 @@ function wsl_component_buddypress_setup_user_avatar()
 	<h3>
 		<label><?php _wsl_e("Users avatars", 'wordpress-social-login') ?></label>
 	</h3>
-	<div class="inside"> 
-		<p> 
-			<?php 
+	<div class="inside">
+		<p>
+			<?php
 				if( get_option( 'wsl_settings_users_avatars' ) == 1 ){
 					_wsl_e("<b>Users avatars</b> is currently set to: <b>Display users avatars from social networks when available</b>", 'wordpress-social-login');
 				}
@@ -67,22 +67,22 @@ function wsl_component_buddypress_setup_user_avatar()
 
 		<p class="description">
 			<?php _wsl_e("To change this setting, go to <b>Widget</b> &gt; <b>Basic Settings</b> &gt <b>Users avatars</b>, then select the type of avatars that you want to display for your users", 'wordpress-social-login') ?>.
-		</p> 
+		</p>
 	</div>
 </div>
 <?php
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_buddypress_setup_profile_mapping()
 {
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 
 	$wsl_settings_buddypress_enable_mapping = get_option( 'wsl_settings_buddypress_enable_mapping' );
 	$wsl_settings_buddypress_xprofile_map   = get_option( 'wsl_settings_buddypress_xprofile_map' );
 
-	# http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Profile.html 
+	# http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Profile.html
 	$ha_profile_fields = array(
 		array( 'field' => 'provider'    , 'label' => _wsl__( "Provider name"            , 'wordpress-social-login'), 'description' => _wsl__( "The the provider or social network name the user used to connected"                                                     , 'wordpress-social-login') ),
 		array( 'field' => 'identifier'  , 'label' => _wsl__( "Provider user Identifier" , 'wordpress-social-login'), 'description' => _wsl__( "The Unique user's ID on the connected provider. Depending on the provider, this field can be an number, Email, URL, etc", 'wordpress-social-login') ),
@@ -107,20 +107,20 @@ function wsl_component_buddypress_setup_profile_mapping()
 		array( 'field' => 'region'      , 'label' => _wsl__( "Region"                   , 'wordpress-social-login'), 'description' => _wsl__( "User's state or region"                                                                                                 , 'wordpress-social-login') ),
 		array( 'field' => 'city'        , 'label' => _wsl__( "City"                     , 'wordpress-social-login'), 'description' => _wsl__( "User's city"                                                                                                            , 'wordpress-social-login') ),
 		array( 'field' => 'zip'         , 'label' => _wsl__( "Zip"                      , 'wordpress-social-login'), 'description' => _wsl__( "User's zipcode"                                                                                                         , 'wordpress-social-login') ),
-	); 
+	);
 ?>
 <div class="stuffbox">
 	<h3>
 		<label><?php _wsl_e("Profile mappings", 'wordpress-social-login') ?></label>
 	</h3>
-	<div class="inside"> 
-		<p> 
+	<div class="inside">
+		<p>
 			<?php _wsl_e("When <b>Profile mapping</b> is enabled, WSL will try to automatically fill in Buddypress users profiles from their social networks profiles", 'wordpress-social-login') ?>.
 		</p>
 
 		<p>
 			<b><?php _wsl_e('Notes', 'wordpress-social-login') ?>:</b>
-		</p> 
+		</p>
 
 		<p class="description">
 			1. <?php _wsl_e('<b>Profile mapping</b> will only work for new users. Profile mapping for returning users will implemented in future version of WSL', 'wordpress-social-login') ?>.
@@ -128,20 +128,20 @@ function wsl_component_buddypress_setup_profile_mapping()
 			2. <?php _wsl_e('Not all the mapped fields will be filled. Some providers and social networks do not give away many information about their users', 'wordpress-social-login') ?>.
 			<br />
 			3. <?php _wsl_e('WSL can only map <b>Single Fields</b>. Supported fields types are: Multi-line Text Areax, Text Box, URL, Date Selector and Number', 'wordpress-social-login') ?>.
-		</p> 
+		</p>
 
 		<table width="100%" border="0" cellpadding="5" cellspacing="2" style="border-top:1px solid #ccc;">
 		  <tr>
 			<td width="200" align="right"><strong><?php _wsl_e("Enable profile mapping", 'wordpress-social-login') ?> :</strong></td>
-			<td> 
+			<td>
 				<select name="wsl_settings_buddypress_enable_mapping" id="wsl_settings_buddypress_enable_mapping" style="width:100px" onChange="toggleMapDiv();">
 					<option <?php if( $wsl_settings_buddypress_enable_mapping == 1 ) echo "selected"; ?> value="1"><?php _wsl_e("Yes", 'wordpress-social-login') ?></option>
-					<option <?php if( $wsl_settings_buddypress_enable_mapping == 2 ) echo "selected"; ?> value="2"><?php _wsl_e("No", 'wordpress-social-login') ?></option> 
-				</select> 
+					<option <?php if( $wsl_settings_buddypress_enable_mapping == 2 ) echo "selected"; ?> value="2"><?php _wsl_e("No", 'wordpress-social-login') ?></option>
+				</select>
 			</td>
 		  </tr>
 		</table>
-		<br>  
+		<br>
 	</div>
 </div>
 
@@ -152,14 +152,14 @@ function wsl_component_buddypress_setup_profile_mapping()
 
 	<div class="inside">
 		<p>
-			<?php _wsl_e("Here you can create a new map by placing WSL users profiles fields to the appropriate destination fields", 'wordpress-social-login') ?>. 
-			<?php _wsl_e('The left column shows the available <b>WSL users profiles fields</b>: These select boxes are called <b>source</b> fields', 'wordpress-social-login') ?>. 
-			<?php _wsl_e('The right column shows the list of <b>Buddypress profiles fields</b>: Those are the <b>destination</b> fields', 'wordpress-social-login') ?>. 
+			<?php _wsl_e("Here you can create a new map by placing WSL users profiles fields to the appropriate destination fields", 'wordpress-social-login') ?>.
+			<?php _wsl_e('The left column shows the available <b>WSL users profiles fields</b>: These select boxes are called <b>source</b> fields', 'wordpress-social-login') ?>.
+			<?php _wsl_e('The right column shows the list of <b>Buddypress profiles fields</b>: Those are the <b>destination</b> fields', 'wordpress-social-login') ?>.
 			<?php _wsl_e('If you don\'t want to map a particular Buddypress field, then leave the source for that field blank', 'wordpress-social-login') ?>.
 		</p>
 
 		<hr />
-		
+
 		<?php
 			if ( bp_has_profile() )
 			{
@@ -169,10 +169,10 @@ function wsl_component_buddypress_setup_profile_mapping()
 
 					bp_the_profile_group();
 					?>
-						<h4><?php echo sprintf( _wsl__("Fields Group '%s'", 'wordpress-social-login'), $group->name ) ?> :</h4>  
-						
+						<h4><?php echo sprintf( _wsl__("Fields Group '%s'", 'wordpress-social-login'), $group->name ) ?> :</h4>
+
 						<table width="100%" border="0" cellpadding="5" cellspacing="2" style="border-top:1px solid #ccc;">
-							<?php 
+							<?php
 								while ( bp_profile_fields() )
 								{
 									global $field;
@@ -184,29 +184,29 @@ function wsl_component_buddypress_setup_profile_mapping()
 												<?php
 													$map = isset( $wsl_settings_buddypress_xprofile_map[$field->id] ) ? $wsl_settings_buddypress_xprofile_map[$field->id] : 0;
 													$can_map_it = true;
-													
+
 													if( ! in_array( $field->type, array( 'textarea', 'textbox', 'url', 'datebox', 'number' ) ) ){
 														$can_map_it = false;
 													}
 												?>
 												<select name="wsl_settings_buddypress_xprofile_map[<?php echo $field->id; ?>]" style="width:255px" id="bb_profile_mapping_selector_<?php echo $field->id; ?>" onChange="showMappingConfirm( <?php echo $field->id; ?> );" <?php if( ! $can_map_it ) echo "disabled"; ?>>
 													<option value=""></option>
-													<?php 
+													<?php
 														if( $can_map_it ){
 															foreach( $ha_profile_fields as $item ){
 															?>
 																<option value="<?php echo $item['field']; ?>" <?php if( $item['field'] == $map ) echo "selected"; ?> ><?php echo $item['label']; ?></option>
-															<?php 
+															<?php
 															}
 														}
 													?>
-												</select> 
+												</select>
 											</td>
 											<td valign="top" align="center" width="50">
-												<img src="<?php echo $assets_base_url; ?>arr_right.png" /> 
+												<img src="<?php echo $assets_base_url; ?>arr_right.png" />
 											</td>
 											<td valign="top">
-												<strong><?php echo $field->name; ?></strong> 
+												<strong><?php echo $field->name; ?></strong>
 												<?php
 													if( ! $can_map_it ){
 													?>
@@ -268,10 +268,10 @@ function wsl_component_buddypress_setup_profile_mapping()
 
 		jQuery( ".bb_profile_mapping_confirm_" + field ).hide();
 
-		jQuery( "#bb_profile_mapping_confirm_" + field + "_" + el ).show(); 
+		jQuery( "#bb_profile_mapping_confirm_" + field + "_" + el ).show();
 	}
 </script>
 <?php
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/contacts/wsl.components.contacts.list.php
+++ b/includes/admin/components/contacts/wsl.components.contacts.list.php
@@ -7,16 +7,16 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
 function wsl_component_contacts_list( $user_id )
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_contacts_list_start" );
-	
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	$user_data = get_userdata( $user_id );
 
@@ -24,7 +24,7 @@ function wsl_component_contacts_list( $user_id )
 	{
 		?>
 			<div style="padding: 15px; margin-bottom: 8px; border: 1px solid #ddd; background-color: #fff;box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
-				<?php _wsl_e( "WordPress user not found!", 'wordpress-social-login' ); ?>. 
+				<?php _wsl_e( "WordPress user not found!", 'wordpress-social-login' ); ?>.
 			</div>
 		<?php
 
@@ -39,18 +39,18 @@ function wsl_component_contacts_list( $user_id )
 	$num_of_pages = 0;
 	$total = wsl_get_stored_hybridauth_user_contacts_count_by_user_id( $user_id );
 	$num_of_pages = ceil( $total / $limit );
-	
+
 	$user_contacts = wsl_get_stored_hybridauth_user_contacts_by_user_id( $user_id, $offset, $limit );
-	
+
 	$actions = array(
 		'edit_details'  => '<a class="button button-secondary thickbox" href="' . admin_url( 'user-edit.php?user_id=' . $user_id . '&TB_iframe=true&width=1150&height=550' ) . '">' . _wsl__( 'Edit user details', 'wordpress-social-login' ) . '</a>',
 		'show_profiles' => '<a class="button button-secondary" href="' . admin_url( 'options-general.php?page=wordpress-social-login&wslp=users&uid=' . $user_id ) . '">' . _wsl__( 'Show user social profiles', 'wordpress-social-login' ) . '</a>',
 	);
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	$actions = apply_filters( 'wsl_component_users_profile_alter_actions_list', $actions, $user_id );
 
-?> 
+?>
 <div style="padding: 15px; margin-bottom: 8px; border: 1px solid #ddd; background-color: #fff;box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
  	<h3 style="margin:0;"><?php echo sprintf( _wsl__("%s's contacts list", 'wordpress-social-login'), $user_data->display_name ); ?></h3>
 
@@ -59,34 +59,34 @@ function wsl_component_contacts_list( $user_id )
 			echo implode( ' ', $actions );
 		?>
 	</p>
-</div> 
+</div>
 
 <style>
 	.widefatop td, .widefatop th { border: 1px solid #DDDDDD; }
-	.widefatop th label { font-weight: bold; }  
+	.widefatop th label { font-weight: bold; }
 </style>
 
 <table cellspacing="0" class="wp-list-table widefat fixed users">
 	<thead>
-		<tr> 
-			<th width="100"><span><?php _wsl_e("Provider", 'wordpress-social-login') ?></span></th>  
-			<th><span><?php _wsl_e("Contact Name", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Contact Email", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Contact Profile Url", 'wordpress-social-login') ?></span></th> 
+		<tr>
+			<th width="100"><span><?php _wsl_e("Provider", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Name", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Email", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Profile Url", 'wordpress-social-login') ?></span></th>
 		</tr>
-	</thead> 
+	</thead>
 	<tfoot>
-		<tr> 
-			<th width="100"><span><?php _wsl_e("Provider", 'wordpress-social-login') ?></span></th>  
-			<th><span><?php _wsl_e("Contact Name", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Contact Email", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Contact Profile Url", 'wordpress-social-login') ?></span></th> 
+		<tr>
+			<th width="100"><span><?php _wsl_e("Provider", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Name", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Email", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Contact Profile Url", 'wordpress-social-login') ?></span></th>
 		</tr>
-	</tfoot> 
+	</tfoot>
 	<tbody id="the-list">
-		<?php 
-			$i = 0; 
-			
+		<?php
+			$i = 0;
+
 			// have contacts?
 			if( ! $user_contacts )
 			{
@@ -98,19 +98,19 @@ function wsl_component_contacts_list( $user_id )
 			foreach( $user_contacts as $item )
 			{
 				?>
-					<tr class="<?php if( ++$i % 2 ) echo "alternate" ?>"> 
+					<tr class="<?php if( ++$i % 2 ) echo "alternate" ?>">
 						<td nowrap>
 							<img src="<?php echo $assets_base_url . strtolower( $item->provider ) . '.png' ?>" style="vertical-align:top;width:16px;height:16px;" /> <?php _wsl_e($item->provider, 'wordpress-social-login') ?>
-						</td> 
+						</td>
 						<td>
 							<?php if( $item->photo_url ) { ?>
-								<img width="32" height="32" class="avatar avatar-32 photo" align="middle" src="<?php echo $item->photo_url ?>" > 
+								<img width="32" height="32" class="avatar avatar-32 photo" align="middle" src="<?php echo $item->photo_url ?>" >
 							<?php } else { ?>
-								<img width="32" height="32" class="avatar avatar-32 photo" align="middle" src="http://www.gravatar.com/avatar/<?php echo md5( strtolower( trim( $item->email ) ) ); ?>" > 
+								<img width="32" height="32" class="avatar avatar-32 photo" align="middle" src="http://www.gravatar.com/avatar/<?php echo md5( strtolower( trim( $item->email ) ) ); ?>" >
 							<?php } ?>
 
 							<strong><?php echo $item->full_name ? $item->full_name : '-'; ?></strong>
-						</td> 
+						</td>
 						<td>
 							<?php if( $item->email ) { ?>
 								<a href="mailto:<?php echo $item->email; ?>"><?php echo $item->email; ?></a>
@@ -124,14 +124,14 @@ function wsl_component_contacts_list( $user_id )
 							<?php } else { ?>
 								-
 							<?php } ?>
-						</td> 
-					</tr> 
-				<?php  
+						</td>
+					</tr>
+				<?php
 			}
-		?> 
+		?>
 	</tbody>
-</table> 
-<?php  
+</table>
+<?php
 	$page_links = paginate_links( array(
 		'base' => add_query_arg( 'pagenum', '%#%' ),
 		'format' => '',
@@ -146,8 +146,8 @@ function wsl_component_contacts_list( $user_id )
 		echo '<div class="tablenav"><div class="tablenav-pages" style="margin: 1em 0">' . $page_links . '</div></div>';
 	}
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_contacts_list_end" );
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/networks/wsl.components.networks.setup.php
+++ b/includes/admin/components/networks/wsl.components.networks.setup.php
@@ -11,7 +11,7 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
@@ -20,13 +20,13 @@ if ( !defined( 'ABSPATH' ) ) exit;
 */
 function wsl_component_networks_setup()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_networks_setup_start" );
 
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG;
-	
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
-	$assets_setup_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/setup/';
+
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
+	$assets_setup_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/setup/';
 
 	// save settings?
 	if( isset( $_REQUEST["enable"] ) && $_REQUEST["enable"] )
@@ -35,8 +35,8 @@ function wsl_component_networks_setup()
 
 		update_option( 'wsl_settings_' . $provider_id . '_enabled', 1 );
 	}
-?> 
-<script> 
+?>
+<script>
 	function toggleproviderkeys(idp)
 	{
 		if(typeof jQuery=="undefined")
@@ -55,7 +55,7 @@ function wsl_component_networks_setup()
 			jQuery('.wsl_tr_settings_' + idp).hide();
 			jQuery('.wsl_div_settings_help_' + idp).hide();
 		}
-		
+
 		return false;
 	}
 
@@ -106,9 +106,9 @@ function wsl_component_networks_setup()
 			$provider_callback_url  = '<span style="color:green">' . $endpoint_url . 'endpoints/' . strtolower( $provider_id ) . '.php</span>';
 		}
 
-		$setupsteps = 0;  
-?>  
-		<a name="setup<?php echo strtolower( $provider_id ) ?>"></a> 
+		$setupsteps = 0;
+?>
+		<a name="setup<?php echo strtolower( $provider_id ) ?>"></a>
 		<div class="stuffbox" id="namediv">
 			<h3>
 				<label class="wp-neworks-label">
@@ -121,10 +121,10 @@ function wsl_component_networks_setup()
 						<tr>
 							<td style="width:125px"><?php _wsl_e("Enabled", 'wordpress-social-login') ?>:</td>
 							<td>
-								<select 
-									name="<?php echo 'wsl_settings_' . $provider_id . '_enabled' ?>" 
-									id="<?php echo 'wsl_settings_' . $provider_id . '_enabled' ?>" 
-									onChange="toggleproviderkeys('<?php echo $provider_id; ?>')" 
+								<select
+									name="<?php echo 'wsl_settings_' . $provider_id . '_enabled' ?>"
+									id="<?php echo 'wsl_settings_' . $provider_id . '_enabled' ?>"
+									onChange="toggleproviderkeys('<?php echo $provider_id; ?>')"
 								>
 									<option value="1" <?php if(   get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo "selected"; ?> ><?php _wsl_e("Yes", 'wordpress-social-login') ?></option>
 									<option value="0" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo "selected"; ?> ><?php _wsl_e("No", 'wordpress-social-login') ?></option>
@@ -139,14 +139,14 @@ function wsl_component_networks_setup()
 									<td><?php _wsl_e("Application ID", 'wordpress-social-login') ?>:</td>
 									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_id' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_id' ); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
-								</tr> 
+								</tr>
 							<?php } else { ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
 									<td><?php _wsl_e("Application Key", 'wordpress-social-login') ?>:</td>
 									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_key' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_key' ); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
-								</tr>  
-							<?php }; ?>	 
+								</tr>
+							<?php }; ?>
 
 							<?php if( ! $require_api_key ) { ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
@@ -171,20 +171,20 @@ function wsl_component_networks_setup()
 									</tr>
 								<?php } ?>
 							<?php } ?>
-						<?php } // if require registration ?> 
+						<?php } // if require registration ?>
 					</tbody>
-				</table> 
+				</table>
 
 				<?php if ( get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) : ?>
-					<?php if (  $provider_id == "Steam" ) : ?> 
+					<?php if (  $provider_id == "Steam" ) : ?>
 						<div class="fade updated">
 							<p>
-								<b><?php _wsl_e("Notes", 'wordpress-social-login') ?>:</b> 
+								<b><?php _wsl_e("Notes", 'wordpress-social-login') ?>:</b>
 							</p>
 							<p>
-								      1. <?php echo sprintf( _wsl__("<b>%s</b> do not require an external application, however if the Web API Key is provided, then WSL will be able to get more information about the connected %s users", 'wordpress-social-login'), $provider_name , $provider_name ) ?>. 
-								<br />2. <?php echo sprintf( _wsl__("<b>%s</b> do not provide their user's email address and by default a random email will then be generated for them instead", 'wordpress-social-login'), $provider_name ) ?>. 
-								
+								      1. <?php echo sprintf( _wsl__("<b>%s</b> do not require an external application, however if the Web API Key is provided, then WSL will be able to get more information about the connected %s users", 'wordpress-social-login'), $provider_name , $provider_name ) ?>.
+								<br />2. <?php echo sprintf( _wsl__("<b>%s</b> do not provide their user's email address and by default a random email will then be generated for them instead", 'wordpress-social-login'), $provider_name ) ?>.
+
 								<?php _wsl_e('To change this behaviour and to force new registered users to provide their emails before they get in, goto <b><a href="options-general.php?page=wordpress-social-login&wslp=bouncer">Bouncer</a></b> and enable <b>Profile Completion</b>', 'wordpress-social-login') ?>.
 							</p>
 						</div>
@@ -197,44 +197,44 @@ function wsl_component_networks_setup()
 					<?php elseif ( in_array( $provider_id, array( "Twitter", "Identica", "Tumblr", "Goodreads", "500px", "Vkontakte", "Gowalla", "Steam" ) ) ) : ?>
 						<div class="fade updated">
 							<p>
-								<b><?php _wsl_e("Note", 'wordpress-social-login') ?>:</b> 
-								
-								<?php echo sprintf( _wsl__("<b>%s</b> do not provide their user's email address and by default a random email will then be generated for them instead", 'wordpress-social-login'), $provider_name ) ?>. 
-								
+								<b><?php _wsl_e("Note", 'wordpress-social-login') ?>:</b>
+
+								<?php echo sprintf( _wsl__("<b>%s</b> do not provide their user's email address and by default a random email will then be generated for them instead", 'wordpress-social-login'), $provider_name ) ?>.
+
 								<?php _wsl_e('To change this behaviour and to force new registered users to provide their emails before they get in, goto <b><a href="options-general.php?page=wordpress-social-login&wslp=bouncer">Bouncer</a></b> and enable <b>Profile Completion</b>', 'wordpress-social-login') ?>.
 							</p>
 						</div>
-					<?php endif; ?> 
-				<?php endif; ?> 
+					<?php endif; ?>
+				<?php endif; ?>
 
 				<br />
 				<div
-					class="wsl_div_settings_help_<?php echo $provider_id; ?>" 
-					style="<?php if( isset( $_REQUEST["enable"] ) && ! isset( $_REQUEST["settings-updated"] ) && $_REQUEST["enable"] == $provider_id ) echo "-"; // <= lolz ?>display:none;" 
-				> 
+					class="wsl_div_settings_help_<?php echo $provider_id; ?>"
+					style="<?php if( isset( $_REQUEST["enable"] ) && ! isset( $_REQUEST["settings-updated"] ) && $_REQUEST["enable"] == $provider_id ) echo "-"; // <= lolz ?>display:none;"
+				>
 					<hr class="wsl" />
-					<?php if (  $provider_id == "Steam" ) : ?> 
-					<?php elseif ( $provider_new_app_link  ) : ?> 
-						<?php _wsl_e('<span style="color:#CB4B16;">Application</span> id and secret (also sometimes referred as <span style="color:#CB4B16;">Consumer</span> key and secret or <span style="color:#CB4B16;">Client</span> id and secret) are what we call an application credentials', 'wordpress-social-login') ?>. 
-						
-						<?php echo sprintf( _wsl__( 'This application will link your website <code>%s</code> to <code>%s API</code> and these credentials are needed in order for <b>%s</b> users to access your website', 'wordpress-social-login'), $_SERVER["SERVER_NAME"], $provider_name, $provider_name ) ?>. 
+					<?php if (  $provider_id == "Steam" ) : ?>
+					<?php elseif ( $provider_new_app_link  ) : ?>
+						<?php _wsl_e('<span style="color:#CB4B16;">Application</span> id and secret (also sometimes referred as <span style="color:#CB4B16;">Consumer</span> key and secret or <span style="color:#CB4B16;">Client</span> id and secret) are what we call an application credentials', 'wordpress-social-login') ?>.
+
+						<?php echo sprintf( _wsl__( 'This application will link your website <code>%s</code> to <code>%s API</code> and these credentials are needed in order for <b>%s</b> users to access your website', 'wordpress-social-login'), $_SERVER["SERVER_NAME"], $provider_name, $provider_name ) ?>.
 						<br />
-						
-						<?php _wsl_e("These credentials may also differ in format, name and content depending on the social network.", 'wordpress-social-login') ?> 
+
+						<?php _wsl_e("These credentials may also differ in format, name and content depending on the social network.", 'wordpress-social-login') ?>
 						<br />
 						<br />
-						
+
 						<?php echo sprintf( _wsl__('To enable authentication with this provider and to register a new <b>%s API Application</b>, follow the steps', 'wordpress-social-login'), $provider_name ) ?>
 						:<br />
-					<?php else: ?>  
-							<p><?php echo sprintf( _wsl__('<b>Done.</b> Nothing more required for <b>%s</b>', 'wordpress-social-login'), $provider_name) ?>.</p> 
-					<?php endif; ?>  
-					<div style="margin-left:40px;"> 
-						<?php if ( $provider_new_app_link  ) : ?> 
+					<?php else: ?>
+							<p><?php echo sprintf( _wsl__('<b>Done.</b> Nothing more required for <b>%s</b>', 'wordpress-social-login'), $provider_name) ?>.</p>
+					<?php endif; ?>
+					<div style="margin-left:40px;">
+						<?php if ( $provider_new_app_link  ) : ?>
 							<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php echo sprintf( _wsl__( 'First go to: <a href="%s" target ="_blank">%s</a>', 'wordpress-social-login'), $provider_new_app_link, $provider_new_app_link ) ?></p>
 
-							<?php if ( $provider_id == "Google" ) : ?>   
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e('On the <b>Dashboard sidebar</b> click on <b>Project</b> then click <em style="color:#0147bb;">&ldquo;Create Project&rdquo;</em>', 'wordpress-social-login') ?>.</p> 
+							<?php if ( $provider_id == "Google" ) : ?>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e('On the <b>Dashboard sidebar</b> click on <b>Project</b> then click <em style="color:#0147bb;">&ldquo;Create Project&rdquo;</em>', 'wordpress-social-login') ?>.</p>
 								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once the project is created. Select that project, then <b>APIs & auth</b> &gt; <b>Consent screen</b> and fill the required information", 'wordpress-social-login') ?>.</p>
 								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e('Then <b>APIs & auth</b> &gt; <b>APIs</b> and enable <em style="color:#0147bb;">&ldquo;Google+ API&rdquo;</em>. If you want to import the user contatcs enable <em style="color:#0147bb;">&ldquo;Contacts API&rdquo;</em> as well', 'wordpress-social-login') ?>.</p>
 								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("After that you will need to create an new application: <b>APIs & auth</b> &gt; <b>Credentials</b> and then click <em style=\"color:#0147bb;\">&ldquo;Create new Client ID&rdquo;</em>", 'wordpress-social-login') ?>.</p>
@@ -243,88 +243,88 @@ function wsl_component_networks_setup()
 								<ul style="margin-left:35px">
 									<li><?php _wsl_e('Select <em style="color:#0147bb;">&ldquo;Web application&rdquo;</em> as your application type', 'wordpress-social-login') ?>.</li>
 									<li><?php _wsl_e("Put your website domain in the <b>Authorized JavaScript origins</b> field. This should match with the current hostname", 'wordpress-social-login') ?> <em style="color:#CB4B16;"><?php echo $_SERVER["SERVER_NAME"]; ?></em>.</li>
-									<li><?php _wsl_e("Provide this URL as the <b>Authorized redirect URI</b> for your application", 'wordpress-social-login') ?>: <br /><?php echo $provider_callback_url ?></li> 
+									<li><?php _wsl_e("Provide this URL as the <b>Authorized redirect URI</b> for your application", 'wordpress-social-login') ?>: <br /><?php echo $provider_callback_url ?></li>
 								</ul>
-							<?php elseif ( $provider_id == "Facebook" ) : ?>   
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Select <b>Add a New App</b> from the <b>Apps</b> menu at the top", 'wordpress-social-login') ?>.</p> 
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Fill out Display Name, Namespace, choose a category and click <b>Create App</b>", 'wordpress-social-login') ?>.</p> 
+							<?php elseif ( $provider_id == "Facebook" ) : ?>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Select <b>Add a New App</b> from the <b>Apps</b> menu at the top", 'wordpress-social-login') ?>.</p>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Fill out Display Name, Namespace, choose a category and click <b>Create App</b>", 'wordpress-social-login') ?>.</p>
 								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Go to Settings page and click on <b>Add Platform</b>. Choose website and enter in the new screen your website url in <b>App Domains</b> and <b>Site URL</b> fields", 'wordpress-social-login') ?>.
-									<?php _wsl_e("They should match with the current hostname", 'wordpress-social-login') ?> <em style="color:#CB4B16;"><?php echo $_SERVER["SERVER_NAME"]; ?></em>.</p> 
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Go to the <b>Status & Review</b> page and choose <b>yes</b> where it says <b>Do you want to make this app and all its live features available to the general public?</b>", 'wordpress-social-login') ?>.</p>  
-							<?php else: ?>  
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Create a new application", 'wordpress-social-login') ?>.</p> 
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Fill out any required fields such as the application name and description", 'wordpress-social-login') ?>.</p> 
-							<?php endif; ?> 
+									<?php _wsl_e("They should match with the current hostname", 'wordpress-social-login') ?> <em style="color:#CB4B16;"><?php echo $_SERVER["SERVER_NAME"]; ?></em>.</p>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Go to the <b>Status & Review</b> page and choose <b>yes</b> where it says <b>Do you want to make this app and all its live features available to the general public?</b>", 'wordpress-social-login') ?>.</p>
+							<?php else: ?>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Create a new application", 'wordpress-social-login') ?>.</p>
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Fill out any required fields such as the application name and description", 'wordpress-social-login') ?>.</p>
+							<?php endif; ?>
 
-							<?php if ( $provider_callback_url && $provider_id != "Google" && $provider_id != "Facebook"  ) : ?> 
+							<?php if ( $provider_callback_url && $provider_id != "Google" && $provider_id != "Facebook"  ) : ?>
 								<p>
 									<?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Provide this URL as the <b>Callback URL</b> for your application", 'wordpress-social-login') ?>:
 									<br />
 									<?php echo $provider_callback_url ?>
-								</p> 
-							<?php endif; ?> 
+								</p>
+							<?php endif; ?>
 
 							<?php if ( $provider_id == "Live" ) : ?>
 								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Put your website domain in the <b>Redirect Domain</b> field. This should match with the current hostname", 'wordpress-social-login') ?> <em style="color:#CB4B16;"><?php echo $_SERVER["SERVER_NAME"]; ?></em>.</p>
-							<?php endif; ?> 
+							<?php endif; ?>
 
 							<?php if ( $provider_id == "LinkedIn" ) : ?>
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e('Choose <b>Live</b> on <b>Live Status</b>.', 'wordpress-social-login') ?></p> 
-							<?php endif; ?> 
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e('Choose <b>Live</b> on <b>Live Status</b>.', 'wordpress-social-login') ?></p>
+							<?php endif; ?>
 
 							<?php if ( $provider_id == "Google" ) : ?>
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered past the created application credentials (Client ID and Secret) into the boxes above", 'wordpress-social-login') ?>.</p> 
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered past the created application credentials (Client ID and Secret) into the boxes above", 'wordpress-social-login') ?>.</p>
 							<?php elseif ( $provider_id == "Twitter" ) : ?>
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered, past the created application credentials (Consumer Key and Secret) into the boxes above", 'wordpress-social-login') ?>.</p> 
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered, past the created application credentials (Consumer Key and Secret) into the boxes above", 'wordpress-social-login') ?>.</p>
 							<?php elseif ( $provider_id == "Facebook" ) : ?>
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Go back to the <b>Dashboard</b> page and past the created application credentials (APP ID and Secret) into the boxes above", 'wordpress-social-login') ?>.</p> 
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Go back to the <b>Dashboard</b> page and past the created application credentials (APP ID and Secret) into the boxes above", 'wordpress-social-login') ?>.</p>
 							<?php else: ?>
-								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered, past the created application credentials into the boxes above", 'wordpress-social-login') ?>.</p> 
-							<?php endif; ?> 
+								<p><?php echo "<b>" . ++$setupsteps . "</b>." ?> <?php _wsl_e("Once you have registered, past the created application credentials into the boxes above", 'wordpress-social-login') ?>.</p>
+							<?php endif; ?>
 
-						<?php endif; ?> 
-						
+						<?php endif; ?>
+
 						<?php if ( $provider_id == "Facebook" ) : ?>
 							<table style="text-align: center;margin-bottom:12px;">
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'facebook/1.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'facebook/1.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'facebook/2.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'facebook/2.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'facebook/3.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'facebook/3.png' ?>"></a></td>
-							</table> 
-						<?php endif; ?> 
+							</table>
+						<?php endif; ?>
 
 						<?php if ( $provider_id == "Google" ) : ?>
 							<table style="text-align: center;margin-bottom:12px;">
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'google/1.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'google/1.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'google/2.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'google/2.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'google/3.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'google/3.png' ?>"></a></td>
-							</table> 
-						<?php endif; ?> 
+							</table>
+						<?php endif; ?>
 
 						<?php if ( $provider_id == "Twitter" ) : ?>
 							<table style="text-align: center;margin-bottom:12px;">
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'twitter/1.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'twitter/1.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'twitter/2.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'twitter/2.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'twitter/3.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'twitter/3.png' ?>"></a></td>
-							</table> 
-						<?php endif; ?> 
+							</table>
+						<?php endif; ?>
 
 						<?php if ( $provider_id == "WordPress" ) : ?>
 							<table style="text-align: center;margin-bottom:12px;">
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'wordpress/1.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'wordpress/1.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'wordpress/2.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'wordpress/2.png' ?>"></a></td>
 								<td><a class="span4 thumbnail" href="<?php echo $assets_setup_base_url . 'wordpress/3.png' ?>" target="_blank"><img src="<?php echo $assets_setup_base_url . 'wordpress/3.png' ?>"></a></td>
-							</table> 
-						<?php endif; ?> 
+							</table>
+						<?php endif; ?>
 					</div>
 
-					<?php if ( $provider_new_app_link  ) : ?> 
+					<?php if ( $provider_new_app_link  ) : ?>
 						<hr />
 						<p>
-							<b><?php _wsl_e("And that's it!", 'wordpress-social-login') ?></b> 
+							<b><?php _wsl_e("And that's it!", 'wordpress-social-login') ?></b>
 							<br />
 							<?php echo sprintf( _wsl__( 'If for some reason you still can\'t manage to create an application for %s, first try to <a href="https://www.google.com/search?q=%s API create application" target="_blank">Google it</a>, then check it on <a href="http://www.youtube.com/results?search_query=%s API create application " target="_blank">Youtube</a>, and if nothing works <a href="options-general.php?page=wordpress-social-login&wslp=help">ask for support</a>', 'wordpress-social-login'), $provider_name, $provider_name, $provider_name ) ?>.
-						</p> 
-					<?php endif; ?> 
+						</p>
+					<?php endif; ?>
 				</div>
 			</div>
 		</div>
@@ -333,8 +333,8 @@ function wsl_component_networks_setup()
 ?>
 	<input type="submit" class="button-primary" value="<?php _wsl_e("Save Settings", 'wordpress-social-login') ?>" />
 <?php
-	// HOOKABLE: 
-	do_action( "wsl_component_networks_setup_end" );	
-} 
+	// HOOKABLE:
+	do_action( "wsl_component_networks_setup_end" );
+}
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/networks/wsl.components.networks.sidebar.php
+++ b/includes/admin/components/networks/wsl.components.networks.sidebar.php
@@ -7,13 +7,13 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
 function wsl_component_networks_sidebar()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_networks_sidebar_start" );
 
 	$sections = array(
@@ -29,11 +29,11 @@ function wsl_component_networks_sidebar()
 		add_action( 'wsl_component_networks_sidebar_sections', $action );
 	}
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( 'wsl_component_networks_sidebar_sections' );
-} 
+}
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_networks_sidebar_what_is_this()
 {
@@ -48,28 +48,28 @@ function wsl_component_networks_sidebar_what_is_this()
 			</p>
 			<p style="padding:0;margin:0 0 12px;">
 				<?php _wsl_e('<b>WordPress Social Login</b> come with a number of useful <b><a href="options-general.php?page=wordpress-social-login&wslp=components">Components</a></b> or add-ons that can be essential for your needs', 'wordpress-social-login') ?>.
-			</p> 
+			</p>
 			<p style="padding:0;margin:0 0 12px;">
 				<?php _wsl_e('If you are still new to things, we recommend that you read the <b><a href="http://miled.github.io/wordpress-social-login/documentation.html" target="_blank">WSL Documentation</a></b> and to make sure your server meet the minimum system requirements by running <b><a href="http://hybridauth.com/hawp4/wp-admin/options-general.php?page=wordpress-social-login&wslp=tools">WSL Diagnostics</a></b>', 'wordpress-social-login') ?>.
 			</p>
 			<p style="padding:0;margin:0 0 12px;">
 				<?php _wsl_e('If you run into any issue, then refer to <b><a href="http://miled.github.io/wordpress-social-login/support.html" target="_blank">Help &amp; Support</a></b>', 'wordpress-social-login') ?>.
-			</p> 
-		</div> 
-	</div> 
-</div> 
+			</p>
+		</div>
+	</div>
+</div>
 <?php
 }
 
 add_action( 'wsl_component_networks_sidebar_what_is_this', 'wsl_component_networks_sidebar_what_is_this' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_networks_sidebar_add_more_idps()
 {
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG;
 
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/32x32/icondock/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/32x32/icondock/';
 ?>
 <div class="postbox">
 	<div class="inside">
@@ -81,7 +81,7 @@ function wsl_component_networks_sidebar_add_more_idps()
 			</p>
 
 			<div style="width: 320px; padding: 10px; border: 1px solid #ddd; background-color: #fff;">
-				<?php 
+				<?php
 					$nb_used = count( $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG );
 
 					foreach( $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG AS $item )
@@ -108,23 +108,23 @@ function wsl_component_networks_sidebar_add_more_idps()
 					{
 						_wsl_e("Well! none left.", 'wordpress-social-login');
 					}
-				?> 
-			</div> 
-		</div> 	
-	</div> 
-</div> 
+				?>
+			</div>
+		</div>
+	</div>
+</div>
 <?php
 }
 
 add_action( 'wsl_component_networks_sidebar_add_more_idps', 'wsl_component_networks_sidebar_add_more_idps' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 function wsl_component_networks_sidebar_basic_insights()
 {
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG;
 
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/32x32/icondock/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/32x32/icondock/';
 ?>
 <div class="postbox">
 	<div class="inside">
@@ -141,7 +141,7 @@ function wsl_component_networks_sidebar_basic_insights()
 					?>
 						<!-- Insights - conversions -->
 						<h4 style="border-bottom:1px solid #ccc"><?php _wsl_e("Conversions", 'wordpress-social-login') ?></h4>
-						<table width="90%"> 
+						<table width="90%">
 							<tr>
 								<td width="60%"><?php _wsl_e("WP users", 'wordpress-social-login') ?></td><td><?php echo $total_users; ?></td>
 							</tr>
@@ -156,10 +156,10 @@ function wsl_component_networks_sidebar_basic_insights()
 						<!-- Insights by provider -->
 						<?php
 							$data = wsl_get_stored_hybridauth_user_profiles_count_by_field( 'provider' );
-						?> 
+						?>
 						<h4 style="border-bottom:1px solid #ccc"><?php _wsl_e("By provider", 'wordpress-social-login') ?></h4>
 						<table width="90%">
-							<?php 
+							<?php
 								$total_profiles_wsl = 0;
 
 								foreach( $data as $item ){
@@ -175,18 +175,18 @@ function wsl_component_networks_sidebar_basic_insights()
 								<?php
 									$total_profiles_wsl += (int) $item->items;
 								}
-							?> 
+							?>
 							<tr>
 								<td align="right">&nbsp;</td><td style="border-top:1px solid #ccc"><b><?php echo $total_profiles_wsl; ?></b> <?php _wsl_e("WSL profiles", 'wordpress-social-login') ?></td>
 							</tr>
 							<tr>
 								<td align="right">&nbsp;</td><td><b><?php echo $total_users_wsl; ?></b> <?php _wsl_e("WSL users", 'wordpress-social-login') ?></td>
 							</tr>
-						</table> 
+						</table>
 
 						<!-- Insights by gender -->
-						<?php 
-							$data = wsl_get_stored_hybridauth_user_profiles_count_by_field( 'gender' );  
+						<?php
+							$data = wsl_get_stored_hybridauth_user_profiles_count_by_field( 'gender' );
 						?>
 						<h4 style="border-bottom:1px solid #ccc"><?php _wsl_e("By gender", 'wordpress-social-login') ?></h4>
 						<table width="90%">
@@ -208,7 +208,7 @@ function wsl_component_networks_sidebar_basic_insights()
 						</table>
 
 						<!-- Insights by age -->
-						<?php 
+						<?php
 							$data = wsl_get_stored_hybridauth_user_profiles_count_by_field( 'age' );
 						?>
 						<h4 style="border-bottom:1px solid #ccc"><?php _wsl_e("By age", 'wordpress-social-login') ?></h4>
@@ -239,13 +239,13 @@ function wsl_component_networks_sidebar_basic_insights()
 						</p>
 					<?php
 				}
-			?> 
-		</div> 
-	</div> 
-</div> 
+			?>
+		</div>
+	</div>
+</div>
 <?php
 }
 
 add_action( 'wsl_component_networks_sidebar_basic_insights', 'wsl_component_networks_sidebar_basic_insights' );
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/users/wsl.components.users.list.php
+++ b/includes/admin/components/users/wsl.components.users.list.php
@@ -7,16 +7,16 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
 function wsl_component_users_list()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_users_list_start" );
 
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	add_thickbox();
 
@@ -26,7 +26,7 @@ function wsl_component_users_list()
 		'edit_details' => '<a class="button button-secondary thickbox" href="' . admin_url( 'users.php?TB_iframe=true&width=1050&height=550' ) . '">' . _wsl__( 'View all your website users', 'wordpress-social-login' ) . '</a>',
 	);
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	$actions = apply_filters( 'wsl_component_users_list_alter_actions_list', $actions );
 ?>
 <div style="padding: 15px; margin-bottom: 8px; border: 1px solid #ddd; background-color: #fff;box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
@@ -54,37 +54,37 @@ function wsl_component_users_list()
 
 	$pagenum = isset( $_GET['pagenum'] ) ? absint( $_GET['pagenum'] ) : 1;
 	$limit = 25; // number of rows in page
-	$offset = ( $pagenum - 1 ) * $limit; 
-	$total = wsl_get_stored_hybridauth_user_profiles_count(); 
-	$num_of_pages = ceil( $total / $limit ); 
+	$offset = ( $pagenum - 1 ) * $limit;
+	$total = wsl_get_stored_hybridauth_user_profiles_count();
+	$num_of_pages = ceil( $total / $limit );
 
 	$users_list = wsl_get_stored_hybridauth_user_profiles_grouped_by_user_id( $offset, $limit );
 ?>
 <table cellspacing="0" class="wp-list-table widefat fixed users">
 	<thead>
-		<tr> 
-			<th width="100"><span><?php _wsl_e("Providers", 'wordpress-social-login') ?></span></th>   
-			<th><span><?php _wsl_e("Username", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Full Name", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("E-mail", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Profile URL", 'wordpress-social-login') ?></span></th> 
+		<tr>
+			<th width="100"><span><?php _wsl_e("Providers", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Username", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Full Name", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("E-mail", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Profile URL", 'wordpress-social-login') ?></span></th>
 			<th width="80"><span><?php _wsl_e("Contacts", 'wordpress-social-login') ?></span></th>
-			<th width="55"><span><?php _wsl_e("User ID", 'wordpress-social-login') ?></span></th>   
+			<th width="55"><span><?php _wsl_e("User ID", 'wordpress-social-login') ?></span></th>
 		</tr>
-	</thead> 
+	</thead>
 	<tfoot>
-		<tr> 
-			<th width="100"><span><?php _wsl_e("Providers", 'wordpress-social-login') ?></span></th>   
-			<th><span><?php _wsl_e("Username", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Full Name", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("E-mail", 'wordpress-social-login') ?></span></th> 
-			<th><span><?php _wsl_e("Profile URL", 'wordpress-social-login') ?></span></th> 
+		<tr>
+			<th width="100"><span><?php _wsl_e("Providers", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Username", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Full Name", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("E-mail", 'wordpress-social-login') ?></span></th>
+			<th><span><?php _wsl_e("Profile URL", 'wordpress-social-login') ?></span></th>
 			<th width="80"><span><?php _wsl_e("Contacts", 'wordpress-social-login') ?></span></th>
-			<th width="55"><span><?php _wsl_e("User ID", 'wordpress-social-login') ?></span></th>   
+			<th width="55"><span><?php _wsl_e("User ID", 'wordpress-social-login') ?></span></th>
 		</tr>
-	</tfoot> 
+	</tfoot>
 	<tbody data-wp-lists="list:user" id="the-list">
-		<?php  
+		<?php
 			$i = 0;
 
 			// have users?
@@ -97,24 +97,24 @@ function wsl_component_users_list()
 			else
 			foreach( $users_list as $items )
 			{
-				$user_id = $items->user_id; 
-				$wsl_user_image = $items->photourl; 
+				$user_id = $items->user_id;
+				$wsl_user_image = $items->photourl;
 
 				$user_data = get_userdata( $user_id );
-				
+
 				if( ! $user_data )
 				{
 					continue;
 				}
 
-				$linked_accounts = wsl_get_stored_hybridauth_user_profiles_by_user_id( $user_id );  
+				$linked_accounts = wsl_get_stored_hybridauth_user_profiles_by_user_id( $user_id );
 			?>
-				<tr class="<?php if( ++$i % 2 ) echo "alternate" ?> tr-contacts"> 
+				<tr class="<?php if( ++$i % 2 ) echo "alternate" ?> tr-contacts">
 					<td nowrap>
-						<?php 
+						<?php
 							foreach( $linked_accounts AS $link )
 							{
-								?> 
+								?>
 									<img src="<?php echo $assets_base_url . strtolower( $link->provider ) . '.png' ?>" style="vertical-align:top;width:16px;height:16px;" /> <?php _wsl_e($link->provider, 'wordpress-social-login') ?><br />
 								<?php
 
@@ -122,14 +122,14 @@ function wsl_component_users_list()
 								{
 									$wsl_user_image = $link->photourl;
 								}
-							} 
-						?> 
-					</td> 	
+							}
+						?>
+					</td>
 					<td class="column-author">
 						<?php if( $wsl_user_image ) { ?>
-							<img width="32" height="32" class="avatar avatar-32 photo" src="<?php echo $wsl_user_image ?>" > 
-						<?php } else { ?>                                              
-							<img width="32" height="32" class="avatar avatar-32 photo" src="http://www.gravatar.com/avatar/<?php echo md5( strtolower( trim( $user_data->user_email ) ) ); ?>" > 
+							<img width="32" height="32" class="avatar avatar-32 photo" src="<?php echo $wsl_user_image ?>" >
+						<?php } else { ?>
+							<img width="32" height="32" class="avatar avatar-32 photo" src="http://www.gravatar.com/avatar/<?php echo md5( strtolower( trim( $user_data->user_email ) ) ); ?>" >
 						<?php } ?>
 
 						<strong><a href="options-general.php?page=wordpress-social-login&wslp=users&uid=<?php echo $user_id ?>"><?php echo $user_data->user_login; ?></a></strong>
@@ -137,12 +137,12 @@ function wsl_component_users_list()
 						<div class="row-actions">
 							<span class="view">
 								<a href="options-general.php?page=wordpress-social-login&wslp=users&uid=<?php echo $user_id ?>"><?php _wsl_e("Profiles", 'wordpress-social-login') ?></a>
-								| 
+								|
 							</span>
 
 							<span class="view">
 								<a href="options-general.php?page=wordpress-social-login&wslp=contacts&uid=<?php echo $user_id ?>"><?php _wsl_e("Contacts", 'wordpress-social-login') ?></a>
-								| 
+								|
 							</span>
 
 							<span class="delete">
@@ -162,12 +162,12 @@ function wsl_component_users_list()
 						<?php } ?>
 					</td>
 					<td>
-						<?php if( $user_data->user_url ) { ?> 
+						<?php if( $user_data->user_url ) { ?>
 							<a href="<?php echo $user_data->user_url; ?>" target="_blank"><?php echo str_ireplace( array("http://www.", "https://www.", "http://","https://"), array('','','','',''), $user_data->user_url ) ?></a>
 						<?php } else { ?>
 							-
 						<?php } ?>
-					</td> 
+					</td>
 					<td align="center">
 						<?php
 							$counts = wsl_get_stored_hybridauth_user_contacts_count_by_user_id( $user_id );
@@ -184,13 +184,13 @@ function wsl_component_users_list()
 							}
 						?>
 					<td align="center"><a class="thickbox" href="<?php echo admin_url( 'user-edit.php?user_id=' . $user_data->ID . '&TB_iframe=true&width=1150&height=550' ); ?>"><?php echo $user_data->ID; ?></a></td>
-				</tr> 
-			<?php 
+				</tr>
+			<?php
 			}
-		?> 
+		?>
 	</tbody>
-</table> 
-<?php  
+</table>
+<?php
 	$page_links = paginate_links( array(
 		'base' => add_query_arg( 'pagenum', '%#%' ),
 		'format' => '',
@@ -204,7 +204,7 @@ function wsl_component_users_list()
 	{
 		echo '<div class="tablenav"><div class="tablenav-pages" style="margin: 1em 0">' . $page_links . '</div></div>';
 	}
-?> 	
+?>
 <script>
 	function confirmDeleteWSLUser()
 	{
@@ -212,11 +212,11 @@ function wsl_component_users_list()
 	}
 </script>
 <?php
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_users_list_end" );
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------
 
 
 function wsl_component_users_delete_social_profiles()
@@ -229,8 +229,8 @@ function wsl_component_users_delete_social_profiles()
 		$user_data = get_userdata( $uid );
 
 		if( $user_data )
-		{ 
-			wsl_delete_stored_hybridauth_user_data( $uid  ); 
+		{
+			wsl_delete_stored_hybridauth_user_data( $uid  );
 
 			?>
 				<div class="fade updated" style="margin: 0px 0px 10px;">
@@ -244,4 +244,4 @@ function wsl_component_users_delete_social_profiles()
 
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/users/wsl.components.users.profiles.php
+++ b/includes/admin/components/users/wsl.components.users.profiles.php
@@ -7,16 +7,16 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
 function wsl_component_users_profiles( $user_id )
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_users_profiles_start" );
 
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	$linked_accounts = wsl_get_stored_hybridauth_user_profiles_by_user_id( $user_id );
 
@@ -25,13 +25,13 @@ function wsl_component_users_profiles( $user_id )
 	{
 ?>
 <div style="padding: 15px; margin-bottom: 8px; border: 1px solid #ddd; background-color: #fff;box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
-	<?php _wsl_e( "This's not a WSL user!", 'wordpress-social-login' ); ?>. 
+	<?php _wsl_e( "This's not a WSL user!", 'wordpress-social-login' ); ?>.
 </div>
 <?php
 		return;
 	}
 
-	# http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Profile.html 
+	# http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Profile.html
 	$ha_profile_fields = array(
 		array( 'field' => 'identifier'  , 'label' => _wsl__( "Provider user ID" , 'wordpress-social-login'), 'description' => _wsl__( "The Unique user's ID on the connected provider. Depending on the provider, this field can be an number, Email, URL, etc", 'wordpress-social-login') ),
 		array( 'field' => 'profileURL'  , 'label' => _wsl__( "Profile URL"      , 'wordpress-social-login'), 'description' => _wsl__( "Link to the user profile on the provider web site"                                                                      , 'wordpress-social-login') ),
@@ -46,7 +46,7 @@ function wsl_component_users_profiles( $user_id )
 		array( 'field' => 'age'         , 'label' => _wsl__( "Age"              , 'wordpress-social-login'), 'description' => _wsl__( "User' age. Note that WSL do not calculate this field. We return it as it was provided"                                  , 'wordpress-social-login') ),
 		array( 'field' => 'birthDay'    , 'label' => _wsl__( "Birth day"        , 'wordpress-social-login'), 'description' => _wsl__( "The day in the month in which the person was born. Not to confuse it with 'Birth date'"                                 , 'wordpress-social-login') ),
 		array( 'field' => 'birthMonth'  , 'label' => _wsl__( "Birth month"      , 'wordpress-social-login'), 'description' => _wsl__( "The month in which the person was born"                                                                                 , 'wordpress-social-login') ),
-		array( 'field' => 'birthYear'   , 'label' => _wsl__( "Birth year"       , 'wordpress-social-login'), 'description' => _wsl__( "The year in which the person was born"                                                                                  , 'wordpress-social-login') ), 
+		array( 'field' => 'birthYear'   , 'label' => _wsl__( "Birth year"       , 'wordpress-social-login'), 'description' => _wsl__( "The year in which the person was born"                                                                                  , 'wordpress-social-login') ),
 		array( 'field' => 'email'       , 'label' => _wsl__( "Email"            , 'wordpress-social-login'), 'description' => _wsl__( "User's email address. Note: some providers like Facebook and Google can provide verified emails. Users with the same verified email will be automatically linked", 'wordpress-social-login') ),
 		array( 'field' => 'phone'       , 'label' => _wsl__( "Phone"            , 'wordpress-social-login'), 'description' => _wsl__( "User's phone number"                                                                                                    , 'wordpress-social-login') ),
 		array( 'field' => 'address'     , 'label' => _wsl__( "Address"          , 'wordpress-social-login'), 'description' => _wsl__( "User's address"                                                                                                         , 'wordpress-social-login') ),
@@ -56,7 +56,7 @@ function wsl_component_users_profiles( $user_id )
 		array( 'field' => 'zip'         , 'label' => _wsl__( "Zip"              , 'wordpress-social-login'), 'description' => _wsl__( "User's zipcode"                                                                                                         , 'wordpress-social-login') ),
 	);
 
-	$user_data = get_userdata( $user_id ); 
+	$user_data = get_userdata( $user_id );
 
 	add_thickbox();
 
@@ -65,7 +65,7 @@ function wsl_component_users_profiles( $user_id )
 		'show_contacts'  => '<a class="button button-secondary" href="' . admin_url( 'options-general.php?page=wordpress-social-login&wslp=contacts&uid=' . $user_id ) . '">' . _wsl__( 'Show user contacts list', 'wordpress-social-login' ) . '</a>',
 	);
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	$actions = apply_filters( 'wsl_component_users_profiles_alter_actions_list', $actions, $user_id );
 ?>
 <style>
@@ -98,8 +98,8 @@ function wsl_component_users_profiles( $user_id )
 		<tr><th width="200"><label><?php _wsl_e("Username", 'wordpress-social-login'); ?></label></th><td><?php echo $user_data->user_login; ?></td></tr>
 		<tr><th><label><?php _wsl_e("Display name", 'wordpress-social-login'); ?></label></th><td><?php echo $user_data->display_name; ?></td></tr>
 		<tr><th><label><?php _wsl_e("E-mail", 'wordpress-social-login'); ?></label></th><td><a href="mailto:<?php echo $user_data->user_email; ?>" target="_blank"><?php echo $user_data->user_email; ?></a></td></tr>
-		<tr><th><label><?php _wsl_e("Website", 'wordpress-social-login'); ?></label></th><td><a href="<?php echo $user_data->user_url; ?>" target="_blank"><?php echo $user_data->user_url; ?></a></td></tr>   
-		<tr><th><label><?php _wsl_e("Registered", 'wordpress-social-login'); ?></label></th><td><?php echo $user_data->user_registered; ?></td></tr> 
+		<tr><th><label><?php _wsl_e("Website", 'wordpress-social-login'); ?></label></th><td><a href="<?php echo $user_data->user_url; ?>" target="_blank"><?php echo $user_data->user_url; ?></a></td></tr>
+		<tr><th><label><?php _wsl_e("Registered", 'wordpress-social-login'); ?></label></th><td><?php echo $user_data->user_registered; ?></td></tr>
 		</tr>
 	 </table>
 </div>
@@ -110,7 +110,7 @@ function wsl_component_users_profiles( $user_id )
 ?>
 <div style="margin-top:15px;padding: 5px 20px 20px; border: 1px solid #ddd; background-color: #fff;">
 
-<h4><img src="<?php echo $assets_base_url . strtolower( $link->provider ) . '.png' ?>" style="vertical-align:top;width:16px;height:16px;" /> <?php _wsl_e("User profile", 'wordpress-social-login'); ?> <small><?php echo sprintf( _wsl__( "as provided by %s", 'wordpress-social-login'), $link->provider ); ?> </small></h4> 
+<h4><img src="<?php echo $assets_base_url . strtolower( $link->provider ) . '.png' ?>" style="vertical-align:top;width:16px;height:16px;" /> <?php _wsl_e("User profile", 'wordpress-social-login'); ?> <small><?php echo sprintf( _wsl__( "as provided by %s", 'wordpress-social-login'), $link->provider ); ?> </small></h4>
 
 <table class="wp-list-table widefat">
 	<?php
@@ -144,18 +144,18 @@ function wsl_component_users_profiles( $user_id )
 							}
 							else
 							{
-								echo $field_value; 
+								echo $field_value;
 							}
 
 							?>
 								<p class="description">
-									<?php echo $item['description']; ?>. 
+									<?php echo $item['description']; ?>.
 								</p>
 							<?php
 						}
 					?>
 				</td>
-			</tr> 
+			</tr>
 		<?php
 		}
 	?>
@@ -164,8 +164,8 @@ function wsl_component_users_profiles( $user_id )
 <?php
 	}
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_component_users_profiles_end" );
 }
 
-// --------------------------------------------------------------------	
+// --------------------------------------------------------------------

--- a/includes/admin/components/watchdog/index.php
+++ b/includes/admin/components/watchdog/index.php
@@ -11,7 +11,7 @@
 */
 
 // Exit if accessed directly
-if ( !defined( 'ABSPATH' ) ) exit; 
+if ( !defined( 'ABSPATH' ) ) exit;
 
 // --------------------------------------------------------------------
 
@@ -19,7 +19,7 @@ function wsl_component_watchdog()
 {
  	if( ! get_option( 'wsl_settings_debug_mode_enabled' ) )
 	{
-		return _wsl_e("<p>Debug mode is disabled.</p>", 'wordpress-social-login'); 
+		return _wsl_e("<p>Debug mode is disabled.</p>", 'wordpress-social-login');
 	}
 
 	if( get_option( 'wsl_settings_debug_mode_enabled' ) == 1 )
@@ -40,17 +40,17 @@ function wsl_component_watchdog_files()
 <div style="padding: 5px 20px; border: 1px solid #ddd; background-color: #fff;">
 	<h3></h3>
 	<h3><?php _wsl_e("Authentication log files viewer", 'wordpress-social-login') ?></h3>
-	
+
 	<form method="post" action="" style="float: right;margin-top:-45px">
 		<select name="log_file">
 			<option value=""> &mdash; <?php _wsl_e("Select a log file to display", 'wordpress-social-login') ?> &mdash;</option>
-			
+
 			<?php
 				$wp_upload_dir = wp_upload_dir();
 				$wsl_path = $wp_upload_dir['basedir'] . '/wordpress-social-login';
 
 				$selected = isset( $_REQUEST['log_file'] ) ? $_REQUEST['log_file'] : '';
-				
+
 				$files = scandir( $wsl_path );
 
 				if( $files )
@@ -78,7 +78,7 @@ function wsl_component_watchdog_files()
 
 function wsl_component_watchdog_database()
 {
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	global $wpdb;
 
@@ -88,12 +88,12 @@ function wsl_component_watchdog_database()
 		if( $_REQUEST['delete'] == 'log' )
 		{
 			$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}wslwatchdog" );
-		}	
-	}	
+		}
+	}
 ?>
 <style>
 	.widefatop td, .widefatop th { border: 1px solid #DDDDDD; }
-	.widefatop th label { font-weight: bold; }  
+	.widefatop th label { font-weight: bold; }
 </style>
 
 <div style="padding: 5px 20px; border: 1px solid #ddd; background-color: #fff;">
@@ -110,11 +110,11 @@ function wsl_component_watchdog_database()
 	<hr />
 
 	<?php
-		$list_sessions = $wpdb->get_results( "SELECT user_ip, session_id, provider, max(id) as max_id FROM `{$wpdb->prefix}wslwatchdog` GROUP BY session_id, provider ORDER BY max_id DESC LIMIT 25" );  
+		$list_sessions = $wpdb->get_results( "SELECT user_ip, session_id, provider, max(id) as max_id FROM `{$wpdb->prefix}wslwatchdog` GROUP BY session_id, provider ORDER BY max_id DESC LIMIT 25" );
 
 		if( ! $list_sessions )
 		{
-			_wsl_e("<p>No log found!</p>", 'wordpress-social-login'); 
+			_wsl_e("<p>No log found!</p>", 'wordpress-social-login');
 		}
 		else
 		{
@@ -126,7 +126,7 @@ function wsl_component_watchdog_database()
 
 				if( ! $provider )
 				{
-					continue; 
+					continue;
 				}
 
 				?>
@@ -144,7 +144,7 @@ function wsl_component_watchdog_database()
 						<th style="text-align:center">&#916;</th>
 					</tr>
 			<?php
-				$list_calls = $wpdb->get_results( "SELECT * FROM `{$wpdb->prefix}wslwatchdog` WHERE session_id = '$session_id' AND provider = '$provider' ORDER BY id ASC LIMIT 500" );  
+				$list_calls = $wpdb->get_results( "SELECT * FROM `{$wpdb->prefix}wslwatchdog` WHERE session_id = '$session_id' AND provider = '$provider' ORDER BY id ASC LIMIT 500" );
 
 				$abandon    = false;
 				$newattempt = false;
@@ -153,7 +153,7 @@ function wsl_component_watchdog_database()
 				$exectime   = 0;
 				$oexectime  = 0;
 				$texectime  = 0;
-			
+
 				foreach( $list_calls as $call_data )
 				{
 					$exectime = (float) $call_data->created_at - ( $oexectime ? $oexectime : (float) $call_data->created_at );
@@ -163,9 +163,9 @@ function wsl_component_watchdog_database()
 					$call_data->action_args = json_decode( $call_data->action_args );
 
 					$newattempt = false;
-					
+
 					$action_name_uid = uniqid();
-					
+
 					$action_desc = 'N.A.';
 					?>
 					<tr  style="<?php if( stristr( $call_data->action_name, 'dbg:' ) ) echo 'background-color:#fffcf5;'; ?> <?php if( 'wsl_render_login_form_user_loggedin' == $call_data->action_name || $call_data->action_name == 'wsl_hook_process_login_before_wp_set_auth_cookie' ) echo 'background-color:#edfff7;'; ?><?php if( 'wsl_process_login_complete_registration_start' == $call_data->action_name ) echo 'background-color:#fefff0;'; ?><?php if( 'wsl_process_login_render_error_page' == $call_data->action_name || $call_data->action_name == 'wsl_process_login_render_notice_page' ) echo 'background-color:#fffafa;'; ?>">
@@ -173,7 +173,7 @@ function wsl_component_watchdog_database()
 							<?php echo $call_data->id; ?>
 						</td>
 						<td nowrap width="350">
-							<span style="color:#<?php 
+							<span style="color:#<?php
 											if( stristr( $call_data->action_name, 'dbg:' ) ){
 												echo '333333';
 											}
@@ -232,7 +232,7 @@ function wsl_component_watchdog_database()
 		function action_args_toggle( action )
 		{
 			jQuery('.action_args_' + action ).toggle();
-			
+
 			return false;
 		}
 	</script>

--- a/includes/admin/wsl.admin.ui.php
+++ b/includes/admin/wsl.admin.ui.php
@@ -6,7 +6,7 @@
 *  (c) 2011-2014 Mohamed Mrassi and contributors | http://wordpress.org/plugins/wordpress-social-login/
 */
 
-/** 
+/**
 * The LOC in charge of displaying WSL Admin GUInterfaces
 */
 
@@ -16,13 +16,13 @@ if ( !defined( 'ABSPATH' ) ) exit;
 // --------------------------------------------------------------------
 
 /**
-* Generate wsl admin pages 
+* Generate wsl admin pages
 *
-* wp-admin/options-general.php?page=wordpress-social-login&.. 
+* wp-admin/options-general.php?page=wordpress-social-login&..
 */
 function wsl_admin_main()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_main_start" );
 
 	if ( ! current_user_can('manage_options') )
@@ -66,7 +66,7 @@ function wsl_admin_main()
 
 	$wslp            = "networks";
 	$wsldwp          = 0;
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	if( isset( $_REQUEST["wslp"] ) )
 	{
@@ -78,12 +78,12 @@ function wsl_admin_main()
 	if( isset( $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS[$wslp] ) && $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS[$wslp]["enabled"] )
 	{
 		if( isset( $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS[$wslp]["action"] ) && $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS[$wslp]["action"] )
-		{ 
+		{
 			do_action( $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS[$wslp]["action"] );
 		}
 		else
 		{
-			include "components/$wslp/index.php"; 
+			include "components/$wslp/index.php";
 		}
 	}
 	else
@@ -93,7 +93,7 @@ function wsl_admin_main()
 
 	wsl_admin_ui_footer();
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_main_end" );
 }
 
@@ -104,28 +104,28 @@ function wsl_admin_main()
 */
 function wsl_admin_ui_header( $wslp = null )
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_header_start" );
 
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_VERSION;
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_ADMIN_TABS;
-	
+
 ?>
 <a name="wsltop"></a>
 <div class="wsl-container">
 
 	<?php
 		// nag
-	
+
 		if( in_array( $wslp, array( 'networks', 'login-widget' ) ) and ( isset( $_REQUEST['settings-updated'] ) or isset( $_REQUEST['enable'] ) ) )
 		{
-			$active_plugins = implode('', (array) get_option('active_plugins') ); 
-			$cache_enabled  = 
-				strpos( $active_plugins, "w3-total-cache"   ) !== false | 
-				strpos( $active_plugins, "wp-super-cache"   ) !== false | 
-				strpos( $active_plugins, "quick-cache"      ) !== false | 
-				strpos( $active_plugins, "wp-fastest-cache" ) !== false | 
-				strpos( $active_plugins, "wp-widget-cache"  ) !== false | 
+			$active_plugins = implode('', (array) get_option('active_plugins') );
+			$cache_enabled  =
+				strpos( $active_plugins, "w3-total-cache"   ) !== false |
+				strpos( $active_plugins, "wp-super-cache"   ) !== false |
+				strpos( $active_plugins, "quick-cache"      ) !== false |
+				strpos( $active_plugins, "wp-fastest-cache" ) !== false |
+				strpos( $active_plugins, "wp-widget-cache"  ) !== false |
 				strpos( $active_plugins, "hyper-cache"      ) !== false;
 
 			if( $cache_enabled )
@@ -139,7 +139,7 @@ function wsl_admin_ui_header( $wslp = null )
 				<?php
 			}
 		}
-		
+
 		if( get_option( 'wsl_settings_development_mode_enabled' ) )
 		{
 			?>
@@ -173,8 +173,8 @@ function wsl_admin_ui_header( $wslp = null )
 	?>
 
 	<div class="alignright">
-		<a style="font-size: 0.9em; text-decoration: none;" target="_blank" href="http://miled.github.io/wordpress-social-login/documentation.html"><?php _wsl_e('Docs', 'wordpress-social-login') ?></a> - 
-		<a style="font-size: 0.9em; text-decoration: none;" target="_blank" href="http://miled.github.io/wordpress-social-login/support.html"><?php _wsl_e('Support', 'wordpress-social-login') ?></a> - 
+		<a style="font-size: 0.9em; text-decoration: none;" target="_blank" href="http://miled.github.io/wordpress-social-login/documentation.html"><?php _wsl_e('Docs', 'wordpress-social-login') ?></a> -
+		<a style="font-size: 0.9em; text-decoration: none;" target="_blank" href="http://miled.github.io/wordpress-social-login/support.html"><?php _wsl_e('Support', 'wordpress-social-login') ?></a> -
 		<a style="font-size: 0.9em; text-decoration: none;" target="_blank" href="https://github.com/miled/wordpress-social-login"><?php _wsl_e('Github', 'wordpress-social-login') ?></a>
 	</div>
 
@@ -211,7 +211,7 @@ function wsl_admin_ui_header( $wslp = null )
 
 	<div id="wsl_admin_tab_content">
 <?php
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_header_end" );
 }
 
@@ -222,23 +222,23 @@ function wsl_admin_ui_header( $wslp = null )
 */
 function wsl_admin_ui_footer()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_footer_start" );
 
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_VERSION;
 ?>
-	</div> <!-- ./wsl_admin_tab_content -->  
-	
+	</div> <!-- ./wsl_admin_tab_content -->
+
 <div class="clear"></div>
 
 <?php
 	wsl_admin_help_us_localize_note();
 
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_footer_end" );
 
 	if( get_option( 'wsl_settings_development_mode_enabled' ) )
-	{ 
+	{
 		wsl_display_dev_mode_debugging_area();
  	}
 }
@@ -250,11 +250,11 @@ function wsl_admin_ui_footer()
 */
 function wsl_admin_ui_error()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_error_start" );
-?> 
+?>
 <div id="wsl_div_warn">
-	<h3 style="margin:0px;"><?php _wsl_e('Oops! We ran into an issue.', 'wordpress-social-login') ?></h3> 
+	<h3 style="margin:0px;"><?php _wsl_e('Oops! We ran into an issue.', 'wordpress-social-login') ?></h3>
 
 	<hr />
 
@@ -271,10 +271,10 @@ function wsl_admin_ui_error()
 	<div>
 		<a class="button-secondary" href="http://miled.github.io/wordpress-social-login/support.html" target="_blank"><?php _wsl_e( "Report as bug", 'wordpress-social-login' ) ?></a>
 		<a class="button-primary" href="options-general.php?page=wordpress-social-login&wslp=components" style="float:<?php if( is_rtl() ) echo 'left'; else echo 'right'; ?>"><?php _wsl_e( "Check enabled components", 'wordpress-social-login' ) ?></a>
-	</div> 
-</div>  
+	</div>
+</div>
 <?php
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_error_end" );
 }
 
@@ -285,7 +285,7 @@ function wsl_admin_ui_error()
 */
 function wsl_admin_ui_fail()
 {
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_fail_start" );
 ?>
 <div class="wsl-container">
@@ -294,39 +294,39 @@ function wsl_admin_ui_fail()
 
 			<hr />
 
-			<p> 
-				<?php _e('Despite the efforts, put into <b>WordPress Social Login</b> in terms of reliability, portability, and maintenance by the plugin <a href="http://profiles.wordpress.org/miled/" target="_blank">author</a> and <a href="https://github.com/hybridauth/WordPress-Social-Login/graphs/contributors" target="_blank">contributors</a>', 'wordpress-social-login') ?>. 
+			<p>
+				<?php _e('Despite the efforts, put into <b>WordPress Social Login</b> in terms of reliability, portability, and maintenance by the plugin <a href="http://profiles.wordpress.org/miled/" target="_blank">author</a> and <a href="https://github.com/hybridauth/WordPress-Social-Login/graphs/contributors" target="_blank">contributors</a>', 'wordpress-social-login') ?>.
 				<b style="color:red;"><?php _e('Your server failed the requirements check for this plugin', 'wordpress-social-login') ?>:</b>
-			</p> 
+			</p>
 
-			<p> 
+			<p>
 				<?php _e('These requirements are usually met by default by most "modern" web hosting providers, however some complications may occur with <b>shared hosting</b> and, or <b>custom wordpress installations</b>', 'wordpress-social-login') ?>.
-			</p> 
+			</p>
 
 			<p>
 				<?php _wsl_e("The minimum server requirements are", 'wordpress-social-login') ?>:
 			</p>
 
 			<ul style="margin-left:60px;">
-				<li><?php _wsl_e("PHP >= 5.2.0 installed", 'wordpress-social-login') ?></li> 
+				<li><?php _wsl_e("PHP >= 5.2.0 installed", 'wordpress-social-login') ?></li>
 				<li><?php _wsl_e("WSL Endpoint URLs reachable", 'wordpress-social-login') ?></li>
 				<li><?php _wsl_e("PHP's default SESSION handling", 'wordpress-social-login') ?></li>
-				<li><?php _wsl_e("PHP/CURL/SSL Extension enabled", 'wordpress-social-login') ?></li> 
-				<li><?php _wsl_e("PHP/JSON Extension enabled", 'wordpress-social-login') ?></li> 
-				<li><?php _wsl_e("PHP/REGISTER_GLOBALS Off", 'wordpress-social-login') ?></li> 
-				<li><?php _wsl_e("jQuery installed on WordPress backoffice", 'wordpress-social-login') ?></li> 
+				<li><?php _wsl_e("PHP/CURL/SSL Extension enabled", 'wordpress-social-login') ?></li>
+				<li><?php _wsl_e("PHP/JSON Extension enabled", 'wordpress-social-login') ?></li>
+				<li><?php _wsl_e("PHP/REGISTER_GLOBALS Off", 'wordpress-social-login') ?></li>
+				<li><?php _wsl_e("jQuery installed on WordPress backoffice", 'wordpress-social-login') ?></li>
 			</ul>
 		</div>
 
 <?php
-	include_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/admin/components/tools/wsl.components.tools.actions.job.php' );
+	include_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/admin/components/tools/wsl.components.tools.actions.job.php' );
 
 	wsl_component_tools_do_diagnostics();
 ?>
 </div>
 <style>.wsl-container .button-secondary { display:none; }</style>
 <?php
-	// HOOKABLE: 
+	// HOOKABLE:
 	do_action( "wsl_admin_ui_fail_end" );
 }
 
@@ -348,25 +348,25 @@ function wsl_admin_welcome_panel()
 
 	// if new user or wsl updated, then we display wsl welcome panel
 	if( get_option( 'wsl_settings_welcome_panel_enabled' ) == wsl_get_version() )
-	{ 
+	{
 		return;
 	}
-	
-	$wslp = "networks"; 
+
+	$wslp = "networks";
 
 	if( isset( $_REQUEST["wslp"] ) )
 	{
 		$wslp = $_REQUEST["wslp"];
-	}	
-?> 
-<!-- 
+	}
+?>
+<!--
 	if you want to know if a UI was made by developer, then here is a tip: he will always use tables
 
 	//> wsl-w-panel is shamelessly borrowed and modified from wordpress welcome-panel
 -->
 <div id="wsl-w-panel">
 	<a href="options-general.php?page=wordpress-social-login&wslp=<?php echo $wslp ?>&wsldwp=1" id="wsl-w-panel-dismiss" <?php if( is_rtl() ) echo 'style="left: 10px;right: auto;"'; ?>><?php _wsl_e("Dismiss", 'wordpress-social-login') ?></a>
-	
+
 	<table width="100%" border="0" style="margin:0;padding:0;">
 		<tr>
 			<td width="10" valign="top"></td>
@@ -386,8 +386,8 @@ function wsl_admin_welcome_panel()
 					<li><a href="http://miled.github.io/wordpress-social-login/overview.html" target="_blank"><?php _wsl_e('Plugin Overview', 'wordpress-social-login') ?></a></li>
 					<li><a href="http://miled.github.io/wordpress-social-login/networks.html" target="_blank"><?php _wsl_e('Setup and Configuration', 'wordpress-social-login') ?></a></li>
 					<li><a href="http://miled.github.io/wordpress-social-login/widget.html" target="_blank"><?php _wsl_e('Customize WSL Widgets', 'wordpress-social-login') ?></a></li>
-					<li><a href="http://miled.github.io/wordpress-social-login/userdata.html" target="_blank"><?php _wsl_e('Manage users and contacts', 'wordpress-social-login') ?></a></li> 
-					<li><a href="http://miled.github.io/wordpress-social-login/documentation.html" target="_blank"><?php _wsl_e('WSL Developer API', 'wordpress-social-login') ?></a></li> 
+					<li><a href="http://miled.github.io/wordpress-social-login/userdata.html" target="_blank"><?php _wsl_e('Manage users and contacts', 'wordpress-social-login') ?></a></li>
+					<li><a href="http://miled.github.io/wordpress-social-login/documentation.html" target="_blank"><?php _wsl_e('WSL Developer API', 'wordpress-social-login') ?></a></li>
 				</ul>
 			</td>
 			<td width="" valign="top">
@@ -397,7 +397,7 @@ function wsl_admin_welcome_panel()
 				</p>
 
 				<ul style="margin-left:25px;">
-					<li><?php _wsl_e('...', 'wordpress-social-login') ?></li> 
+					<li><?php _wsl_e('...', 'wordpress-social-login') ?></li>
 				</ul>
 			</td>
 		</tr>
@@ -406,9 +406,9 @@ function wsl_admin_welcome_panel()
 				&nbsp;
 			</td>
 		</tr>
-	</table> 
+	</table>
 </div>
-<?php 
+<?php
 }
 
 // --------------------------------------------------------------------
@@ -418,11 +418,11 @@ function wsl_admin_welcome_panel()
 */
 function wsl_admin_help_us_localize_note()
 {
-	return; // nothing, until I decide otherwise.. 
+	return; // nothing, until I decide otherwise..
 
-	$assets_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+	$assets_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 
-	?> 
+	?>
 		<div id="l10n-footer">
 			<br /><br />
 			<img src="<?php echo $assets_url ?>flags.png">
@@ -444,20 +444,20 @@ function wsl_render_wp_editor( $name, $content )
 	if( ! function_exists( 'wp_editor' ) )
 	{
 		?>
-			<textarea style="width:100%;height:100px;margin-top:6px;" name="<?php echo $name ?>"><?php echo htmlentities( $content ); ?></textarea> 
+			<textarea style="width:100%;height:100px;margin-top:6px;" name="<?php echo $name ?>"><?php echo htmlentities( $content ); ?></textarea>
 		<?php
 		return;
 	}
 ?>
-<div class="postbox"> 
+<div class="postbox">
 	<div class="wp-editor-textarea" style="background-color: #FFFFFF;">
-		<?php 
-			wp_editor( 
-				$content, $name, 
-				array( 'textarea_name' => $name, 'media_buttons' => true, 'tinymce' => array( 'theme_advanced_buttons1' => 'formatselect,forecolor,|,bold,italic,underline,|,justifyleft,justifycenter,justifyright,justifyfull,|,link,unlink' ) ) 
+		<?php
+			wp_editor(
+				$content, $name,
+				array( 'textarea_name' => $name, 'media_buttons' => true, 'tinymce' => array( 'theme_advanced_buttons1' => 'formatselect,forecolor,|,bold,italic,underline,|,justifyleft,justifycenter,justifyright,justifyfull,|,link,unlink' ) )
 			);
 		?>
-	</div> 
+	</div>
 </div>
 <?php
 }
@@ -465,7 +465,7 @@ function wsl_render_wp_editor( $name, $content )
 // --------------------------------------------------------------------
 
 /**
-* Display WordPress Social Login on settings as submenu 
+* Display WordPress Social Login on settings as submenu
 */
 function wsl_admin_menu()
 {
@@ -474,7 +474,7 @@ function wsl_admin_menu()
 	add_action( 'admin_init', 'wsl_register_setting' );
 }
 
-add_action('admin_menu', 'wsl_admin_menu' ); 
+add_action('admin_menu', 'wsl_admin_menu' );
 
 // --------------------------------------------------------------------
 
@@ -485,10 +485,10 @@ function wsl_add_admin_stylesheets()
 {
 	if( ! wp_style_is( 'wsl-admin', 'registered' ) )
 	{
-		wp_register_style( "wsl-admin", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "/assets/css/admin.css" ); 
+		wp_register_style( "wsl-admin", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "assets/css/admin.css" );
 	}
 
-	wp_enqueue_style( "wsl-admin" ); 
+	wp_enqueue_style( "wsl-admin" );
 }
 
 add_action( 'admin_enqueue_scripts', 'wsl_add_admin_stylesheets' );

--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -198,7 +198,7 @@ function wsl_process_login_begin()
 	// load hybridauth main class
 	if( ! class_exists('Hybrid_Auth', false) )
 	{
-		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "/hybridauth/Hybrid/Auth.php";
+		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "hybridauth/Hybrid/Auth.php";
 	}
 
 	// HOOKABLE:
@@ -997,7 +997,7 @@ function wsl_process_login_get_provider_adapter( $provider )
 {
 	if( ! class_exists( 'Hybrid_Auth', false ) )
 	{
-		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "/hybridauth/Hybrid/Auth.php";
+		require_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . "hybridauth/Hybrid/Auth.php";
 	}
 
 	return Hybrid_Auth::getAdapter( $provider );
@@ -1077,7 +1077,7 @@ function wsl_process_login_render_error_page( $e, $config = null, $provider = nu
 	// HOOKABLE:
 	do_action( "wsl_process_login_render_error_page", $e, $config, $provider, $adapter );
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 
 	$message  = _wsl__("Unspecified error!", 'wordpress-social-login');
 	$notes    = "";

--- a/includes/services/wsl.utilities.php
+++ b/includes/services/wsl.utilities.php
@@ -429,7 +429,7 @@ function wsl_generate_backtrace()
 
     for ( $i = 0; $i < $length; $i++ )
     {
-        $result[] = ( $i + 1 )  . ')' . str_ireplace( array( realpath( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/' ), realpath( WP_PLUGIN_DIR . '/' ), realpath( ABSPATH . '/' ) ) , '', substr( $trace[$i], strpos( $trace[$i], ' ' ) ) );
+        $result[] = ( $i + 1 )  . ')' . str_ireplace( array( realpath( WORDPRESS_SOCIAL_LOGIN_ABS_PATH ), realpath( WP_PLUGIN_DIR . '/' ), realpath( ABSPATH . '/' ) ) , '', substr( $trace[$i], strpos( $trace[$i], ' ' ) ) );
     }
 
     return "\n\t" . implode( "\n\t", $result );

--- a/includes/widgets/wsl.auth.widgets.php
+++ b/includes/widgets/wsl.auth.widgets.php
@@ -97,7 +97,7 @@ do_action( 'wsl_render_login_form_start' );
 		$social_icon_set = "wpzoom/";
 	}
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/32x32/' . $social_icon_set . '/';
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/32x32/' . $social_icon_set . '/';
 
 	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url;
 
@@ -370,7 +370,7 @@ function wsl_shortcode_wordpress_social_login_meta( $args = array() )
 		return;
 	}
 
-	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	$assets_base_url  = isset( $args['assets_base_url'] ) && $args['assets_base_url'] ? $args['assets_base_url'] : $assets_base_url;
 
@@ -516,7 +516,7 @@ function wsl_add_stylesheets()
 {
 	if( ! wp_style_is( 'wsl-widget', 'registered' ) )
 	{
-		wp_register_style( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "/assets/css/style.css" );
+		wp_register_style( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "assets/css/style.css" );
 	}
 
 	wp_enqueue_style( "wsl-widget" );
@@ -539,7 +539,7 @@ function wsl_add_javascripts()
 
 	if( ! wp_script_is( 'wsl-widget', 'registered' ) )
 	{
-		wp_register_script( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "/assets/js/widget.js" );
+		wp_register_script( "wsl-widget", WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . "assets/js/widget.js" );
 	}
 
 	wp_enqueue_script( "jquery" );

--- a/includes/widgets/wsl.error.pages.php
+++ b/includes/widgets/wsl.error.pages.php
@@ -30,7 +30,7 @@ if( ! function_exists( 'wsl_render_notice_page' ) )
 {
 	function wsl_render_notice_page( $message )
 	{
-		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
+		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>
@@ -135,7 +135,7 @@ if( ! function_exists( 'wsl_render_error_page' ) )
 {
 	function wsl_render_error_page( $message, $notes = null, $provider = null, $api_error = null, $php_exception = null )
 	{
-		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';
+		$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>

--- a/includes/widgets/wsl.loading.screens.php
+++ b/includes/widgets/wsl.loading.screens.php
@@ -18,10 +18,10 @@ if( !defined( 'ABSPATH' ) ) exit;
 /**
 * Display a loading screen while the WSL is redirecting the user to a given provider for authentication
 *
-* Note: 
+* Note:
 *   In case you want to customize the content generated, you may redefine this function
-*   This function should redirect to the current url PLUS '&redirect_to_provider=true', see javascript function init() defined bellow 
-*   And make sure the script DIES at the end. 
+*   This function should redirect to the current url PLUS '&redirect_to_provider=true', see javascript function init() defined bellow
+*   And make sure the script DIES at the end.
 *
 *   The $provider name is passed as a parameter.
 */
@@ -29,12 +29,12 @@ if( ! function_exists( 'wsl_render_redirect_to_provider_loading_screen' ) )
 {
 	function wsl_render_redirect_to_provider_loading_screen( $provider )
 	{
-		$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/'; 
+		$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>
 		<meta name="robots" content="NOINDEX, NOFOLLOW">
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /> 
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title><?php _wsl_e("Redirecting...", 'wordpress-social-login') ?> - <?php bloginfo('name'); ?></title>
 		<style type="text/css">
 			html {
@@ -71,7 +71,7 @@ if( ! function_exists( 'wsl_render_redirect_to_provider_loading_screen' ) )
 			}
 		</script>
 	</head>
-	<body id="loading-screen" onload="init();"> 
+	<body id="loading-screen" onload="init();">
 		<table width="100%" border="0">
 			<tr>
 				<td align="center"><img src="<?php echo $assets_base_url ?>loading.gif" /></td>
@@ -81,11 +81,11 @@ if( ! function_exists( 'wsl_render_redirect_to_provider_loading_screen' ) )
 					<div>
 						<?php echo sprintf( _wsl__( "Contacting <b>%s</b>, please wait...", 'wordpress-social-login'), _wsl__( ucfirst( $provider ), 'wordpress-social-login') )  ?>
 					</div>
-				</td> 
-			</tr> 
-		</table>   
+				</td>
+			</tr>
+		</table>
 	</body>
-</html> 
+</html>
 <?php
 		die();
 	}
@@ -94,7 +94,7 @@ if( ! function_exists( 'wsl_render_redirect_to_provider_loading_screen' ) )
 /**
 * Display a loading screen after a user come back from provider and while WSL is procession his profile, contacts, etc.
 *
-* Note: 
+* Note:
 *   In case you want to customize the content generated, you may redefine this function
 *   Just make sure the script DIES at the end.
 */
@@ -103,20 +103,20 @@ if( ! function_exists( 'wsl_render_return_from_provider_loading_screen' ) )
 	function wsl_render_return_from_provider_loading_screen( $provider, $authenticated_url, $redirect_to, $wsl_settings_use_popup )
 	{
 		/*
-		* If Authentication displayis undefined or eq Popup ($wsl_settings_use_popup==1) 
+		* If Authentication displayis undefined or eq Popup ($wsl_settings_use_popup==1)
 		* > create a from with javascript in parent window and submit it to wp-login.php ($authenticated_url)
 		* > with action=wordpress_social_authenticated, then close popup
 		*
-		* If Authentication display eq In Page ($wsl_settings_use_popup==2) 
-		* > create a from in page then submit it to wp-login.php with action=wordpress_social_authenticated 
+		* If Authentication display eq In Page ($wsl_settings_use_popup==2)
+		* > create a from in page then submit it to wp-login.php with action=wordpress_social_authenticated
 		*/
 
-		$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/';  
+		$assets_base_url  = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/';
 ?>
 <!DOCTYPE html>
 	<head>
 		<meta name="robots" content="NOINDEX, NOFOLLOW">
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /> 
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<title><?php _wsl_e("Redirecting...", 'wordpress-social-login') ?> - <?php bloginfo('name'); ?></title>
 		<style type="text/css">
 			html {
@@ -176,7 +176,7 @@ if( ! function_exists( 'wsl_render_return_from_provider_loading_screen' ) )
 			}
 		</script>
 	</head>
-	<body id="loading-screen" onload="init();"> 
+	<body id="loading-screen" onload="init();">
 		<table width="100%" border="0">
 			<tr>
 				<td align="center"><img src="<?php echo $assets_base_url ?>loading.gif" /></td>
@@ -186,17 +186,17 @@ if( ! function_exists( 'wsl_render_return_from_provider_loading_screen' ) )
 					<div>
 						<?php echo _wsl_e( "Processing, please wait...", 'wordpress-social-login');  ?>
 					</div>
-				</td> 
-			</tr> 
+				</td>
+			</tr>
 		</table>
 
 		<form name="loginform" method="post" action="<?php echo $authenticated_url; ?>">
-			<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo esc_url( $redirect_to ); ?>"> 
-			<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>"> 
+			<input type="hidden" id="redirect_to" name="redirect_to" value="<?php echo esc_url( $redirect_to ); ?>">
+			<input type="hidden" id="provider" name="provider" value="<?php echo $provider ?>">
 			<input type="hidden" id="action" name="action" value="wordpress_social_authenticated">
 		</form>
 	</body>
-</html> 
+</html>
 <?php
 		die();
 	}

--- a/includes/widgets/wsl.users.gateway.php
+++ b/includes/widgets/wsl.users.gateway.php
@@ -27,7 +27,7 @@ function wsl_process_login_new_users_gateway( $provider, $redirect_to, $hybridau
 	// HOOKABLE:
 	do_action( "wsl_process_login_new_users_gateway_start", $provider, $redirect_to, $hybridauth_user_profile );
 
-	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
+	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'assets/img/16x16/';
 
 	// remove wsl widget
 	remove_action( 'register_form', 'wsl_render_auth_widget_in_wp_register_form' );

--- a/tests/test_users.php
+++ b/tests/test_users.php
@@ -18,11 +18,11 @@ class WSL_Test_Users extends WP_UnitTestCase
 	{
 		parent::setUp();
 
-		$this->someUserID = wp_create_user( $this->someUserLogin, wp_generate_password(), $this->someUserMail ); 
+		$this->someUserID = wp_create_user( $this->someUserLogin, wp_generate_password(), $this->someUserMail );
 
-		include_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/hybridauth/Hybrid/User_Profile.php';
+		include_once WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'hybridauth/Hybrid/User_Profile.php';
 
-		$this->someUserProfile = new Hybrid_User_Profile(); 
+		$this->someUserProfile = new Hybrid_User_Profile();
 
 		$this->someUserProfile->identifier    = 'identifier';
 		$this->someUserProfile->firstName     = 'firstName';
@@ -79,7 +79,7 @@ class WSL_Test_Users extends WP_UnitTestCase
 	}
 
 	/*
-	* make sure users social profiles are deleted when the associated wordpress user is deleted 
+	* make sure users social profiles are deleted when the associated wordpress user is deleted
 	*/
 	function test_delete_user_social_profile()
 	{

--- a/wp-social-login.php
+++ b/wp-social-login.php
@@ -89,14 +89,14 @@ if( file_exists( WP_PLUGIN_DIR . '/wp-social-login-custom.php' ) )
 /**
 * Define WSL constants, if not already defined
 */
-defined( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH' ) 
-	|| define( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH', WP_PLUGIN_DIR . '/wordpress-social-login' );
+defined( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH' )
+	|| define( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH', plugin_dir_path( __FILE__ ) );
 
-defined( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL' ) 
-	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', plugins_url() . '/wordpress-social-login' );
+defined( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL' )
+	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-defined( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL' ) 
-	|| define( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL', WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/hybridauth/' );
+defined( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL' )
+	|| define( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL', WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'hybridauth/' );
 
 // --------------------------------------------------------------------
 
@@ -202,7 +202,7 @@ if( ! function_exists( 'wsl_load_plugin_textdomain' ) )
 {
 	function wsl_load_plugin_textdomain()
 	{
-		load_plugin_textdomain( 'wordpress-social-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' ); 
+		load_plugin_textdomain( 'wordpress-social-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	}
 }
 
@@ -228,34 +228,34 @@ function _wsl__( $text, $domain )
 	return __( $text, $domain );
 }
 
-// -------------------------------------------------------------------- 
+// --------------------------------------------------------------------
 
 /* includes */
 
 # WSL Setup & Settings
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/settings/wsl.providers.php'            ); // List of supported providers (mostly provided by hybridauth library) 
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/settings/wsl.database.php'             ); // Install/Uninstall WSL database tables
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/settings/wsl.initialization.php'       ); // Check WSL requirements and register WSL settings
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/settings/wsl.compatibilities.php'      ); // Check and upgrade WSL database/settings (for older versions)
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/settings/wsl.providers.php'            ); // List of supported providers (mostly provided by hybridauth library)
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/settings/wsl.database.php'             ); // Install/Uninstall WSL database tables
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/settings/wsl.initialization.php'       ); // Check WSL requirements and register WSL settings
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/settings/wsl.compatibilities.php'      ); // Check and upgrade WSL database/settings (for older versions)
 
 # Services & Utilities
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.authentication.php'       ); // Authenticate users via social networks. <- that's the most important script
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.mail.notification.php'    ); // Emails and notifications
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.user.avatar.php'          ); // Display users avatar
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.user.data.php'            ); // User data functions (database related)
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.utilities.php'            ); // Unclassified functions & utilities
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/services/wsl.watchdog.php'             ); // WSL logging agent
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.authentication.php'       ); // Authenticate users via social networks. <- that's the most important script
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.mail.notification.php'    ); // Emails and notifications
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.user.avatar.php'          ); // Display users avatar
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.user.data.php'            ); // User data functions (database related)
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.utilities.php'            ); // Unclassified functions & utilities
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/services/wsl.watchdog.php'             ); // WSL logging agent
 
-# WSL Widgets & Front-end interfaces 
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/widgets/wsl.auth.widgets.php'          ); // Authentication widget generators (where WSL widget/icons are displayed)
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/widgets/wsl.users.gateway.php'         ); // Accounts linking + Profile Completion
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/widgets/wsl.error.pages.php'           ); // Generate WSL notices end errors pages
-require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/widgets/wsl.loading.screens.php'       ); // Generate WSL loading screens
+# WSL Widgets & Front-end interfaces
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/widgets/wsl.auth.widgets.php'          ); // Authentication widget generators (where WSL widget/icons are displayed)
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/widgets/wsl.users.gateway.php'         ); // Accounts linking + Profile Completion
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/widgets/wsl.error.pages.php'           ); // Generate WSL notices end errors pages
+require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/widgets/wsl.loading.screens.php'       ); // Generate WSL loading screens
 
 # WSL Admin interfaces
 if( is_admin() && ( !defined( 'DOING_AJAX' ) || !DOING_AJAX ) )
 {
-	require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . '/includes/admin/wsl.admin.ui.php'        ); // The entry point to WSL Admin interfaces 
+	require_once( WORDPRESS_SOCIAL_LOGIN_ABS_PATH . 'includes/admin/wsl.admin.ui.php'        ); // The entry point to WSL Admin interfaces
 }
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
Closes #91 
- Modify plugin constants
`WORDPRESS_SOCIAL_LOGIN_ABS_PATH`
`WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL` 
values with proper native WordPress functions 
`plugin_dir_path( __FILE__ )`
`plugin_dir_url( __FILE__ )`

- Remove (now) unnecessary trailing slash in other files, because both `plugin_dir_path() and plugin_dir_url()` return path/url **with** trailing slash

See for details:
https://codex.wordpress.org/Function_Reference/plugin_dir_path
https://codex.wordpress.org/Function_Reference/plugin_dir_url