### PR TITLE
first_name and last_name user meta patch

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -722,6 +722,10 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		$user_id = wp_insert_user( $userdata );
 	}
 
+  // wp_insert_user may fail on first and last name meta, expliciting setting to correct.
+  update_user_meta($user_id, 'first_name', apply_filters( 'pre_user_first_name',$userdata['first_name']));
+  update_user_meta($user_id, 'last_name', apply_filters( 'pre_user_last_name', $userdata['last_name']));
+
 	// do not continue without user_id
 	if( ! $user_id || ! is_integer( $user_id ) )
 	{


### PR DESCRIPTION
wp_insert_user doesn't update first_name and last_name fields consistently.  Updating the meta fields directly after the insert corrects the issue.  