### PR TITLE
Fix email confirmation in WSL

### DIFF
--- a/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
+++ b/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
@@ -206,7 +206,7 @@ function wsl_component_bouncer_setup_user_moderation()
 			<td>
 				<?php
 					$users_moderation_level = array(
-						100 => "E-mail Confirmation &mdash; Yield to Theme My Login plugin",
+						101 => "E-mail Confirmation &mdash; Yield to Theme My Login plugin",
 						102 => "Admin Approval &mdash; Yield to Theme My Login plugin",
 					);
 

--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -821,6 +821,8 @@ function wsl_process_login_authenticate_wp_user( $user_id, $provider, $redirect_
 			$redirect_to = site_url( 'wp-login.php', 'login_post' ) . ( strpos( site_url( 'wp-login.php', 'login_post' ), '?' ) ? '&' : '?' ) . "pending=activation";
 
 			// send a new e-mail/activation notification - if TML not enabled, we ensure WSL to keep it quiet
+			$errors = new WP_Error();
+			do_action( 'register_post', $wp_user->user_nicename, $wp_user->$user_email, $errors );
 			@ Theme_My_Login_User_Moderation::new_user_activation_notification( $user_id );
 		}
 


### PR DESCRIPTION
Email confirmation functionality appears to have degraded. This PR fixes email confirmation, and enables the customisation of the confirmation email using the standard TML customisation form.