### PR TITLE
Added check for explicit redirect_to on login page

### DIFF
--- a/includes/widgets/wsl.auth.widgets.php
+++ b/includes/widgets/wsl.auth.widgets.php
@@ -191,8 +191,19 @@ function wsl_render_auth_widget( $args = array() )
 				}
 			}
 
+			// Use the provided redirect_to if it is given and this is the login page.
+			if ( in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) &&
+					 !empty( $_REQUEST["redirect_to"] ) )
+			{
+				$redirect_to = $_REQUEST["redirect_to"];
+			}
+			else
+			{
+				$redirect_to = $current_page_url;
+			}
+
 			// build authentication url
-			$authenticate_url = $authenticate_base_url . "provider=" . $provider_id . "&redirect_to=" . urlencode( $current_page_url );
+			$authenticate_url = $authenticate_base_url . "provider=" . $provider_id . "&redirect_to=" . urlencode( $redirect_to );
 
 			// http://codex.wordpress.org/Function_Reference/esc_url
 			$authenticate_url = esc_url( $authenticate_url );

--- a/includes/widgets/wsl.auth.widgets.php
+++ b/includes/widgets/wsl.auth.widgets.php
@@ -171,6 +171,17 @@ function wsl_render_auth_widget( $args = array() )
 
 	$no_idp_used = true;
 
+	// Use the provided redirect_to if it is given and this is the login page.
+	if ( in_array( $GLOBALS["pagenow"], array( "wp-login.php", "wp-register.php" ) ) &&
+		 !empty( $_REQUEST["redirect_to"] ) )
+	{
+		$redirect_to = $_REQUEST["redirect_to"];
+	}
+	else
+	{
+		$redirect_to = $current_page_url;
+	}
+
 	// display provider icons
 	foreach( $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG AS $item )
 	{
@@ -189,17 +200,6 @@ function wsl_render_auth_widget( $args = array() )
 				{
 					continue;
 				}
-			}
-
-			// Use the provided redirect_to if it is given and this is the login page.
-			if ( in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) &&
-					 !empty( $_REQUEST["redirect_to"] ) )
-			{
-				$redirect_to = $_REQUEST["redirect_to"];
-			}
-			else
-			{
-				$redirect_to = $current_page_url;
 			}
 
 			// build authentication url


### PR DESCRIPTION
Please let me know if this makes sense. I added it because I'm using a restricted page plugin so if a user tries to access a protected resource, they are redirected to the login page. So the only social widget is on the login page itself. When the login page is loaded, a redirect_to is already provided, pointing to the protected resource. So the code I added looks for that redirect_to parameter and uses it instead of the current page. This only happens if the current page is the login page.

I hope this doesn't conflict with other usages of the plugin. Look forward to discussing.

