### PR TITLE
Fix issue #125 wsl_store_hybridauth_user_profile

### DIFF
--- a/includes/services/wsl.user.data.php
+++ b/includes/services/wsl.user.data.php
@@ -208,7 +208,7 @@ function wsl_store_hybridauth_user_profile( $user_id, $provider, $profile )
 	}
 
 	$table_data = array(
-		"id"         => 'null',
+		"id"         => null,
 		"user_id"    => $user_id,
 		"provider"   => $provider,
 		"object_sha" => $object_sha


### PR DESCRIPTION
Changes default value for `id` column from `'null'` to `null` to match the database schema for the associated table.

I believe this fixes both issue #125 and #53 
