### PR TITLE
Do not load popup scripts on mobile, to be consistent.

### DIFF
--- a/includes/widgets/wsl.auth.widgets.php
+++ b/includes/widgets/wsl.auth.widgets.php
@@ -522,7 +522,12 @@ add_action( 'login_enqueue_scripts', 'wsl_add_stylesheets' );
 */
 function wsl_add_javascripts()
 {
-	if( get_option( 'wsl_settings_use_popup' ) != 1 )
+	$wsl_settings_use_popup = get_option( 'wsl_settings_use_popup' );
+    
+    // if a user is visiting using a mobile device, WSL will fall back to more in page
+	$wsl_settings_use_popup = function_exists( 'wp_is_mobile' ) ? wp_is_mobile() ? 2 : $wsl_settings_use_popup : $wsl_settings_use_popup;
+
+	if( $wsl_settings_use_popup != 1 )
 	{
 		return null;
 	}


### PR DESCRIPTION
Throughout the rest of the plugin, the popup settings are overrode when 'wp_is_mobile' evaluates to true.For proper function of mobile devices, this same logic should be applied to when the popup scripts should load.

Thanks!
