### PR TITLE
Fix login error when a linked account exists with filters by e-mail address enabled

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -489,11 +489,11 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
                         }
                         while( ! $shall_pass );
                 }
+
+                $hybridauth_user_email = $requested_user_email;
         }else{
 	        $wordpress_user_id = $user_id;
         }
-	$hybridauth_user_email = $requested_user_email;
-
 
 	// Bouncer::Filters by e-mails addresses
 	if( get_option( 'wsl_settings_bouncer_new_users_restrict_email_enabled' ) == 1 )


### PR DESCRIPTION
To reproduce:
1. Create a WP account
2. Restrict e-mail sign-ups using "Filters by e-mail addresses"
3. Login via WSL and link the account
4. In a new browser, try to login via WSL.

The login will always fail because the e-mail assigned will be empty, which
then gets rejected by the e-mail filter.
