### PR TITLE
Added the option to only allow connections for already registered users

### DIFF
--- a/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
+++ b/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
@@ -70,6 +70,7 @@ function wsl_component_bouncer_setup_wsl_widget()
 				<select name="wsl_settings_bouncer_registration_enabled">
 					<option <?php if( get_option( 'wsl_settings_bouncer_registration_enabled' ) == 1 ) echo "selected"; ?> value="1"><?php _wsl_e("Yes", 'wordpress-social-login') ?></option>
 					<option <?php if( get_option( 'wsl_settings_bouncer_registration_enabled' ) == 2 ) echo "selected"; ?> value="2"><?php _wsl_e("No", 'wordpress-social-login') ?></option> 
+					<option <?php if( get_option( 'wsl_settings_bouncer_registration_enabled' ) == 3 ) echo "selected"; ?> value="3"><?php _wsl_e("No, but allow existing users to connect", 'wordpress-social-login') ?></option>
 				</select>
 			</td>
 		  </tr> 

--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -448,6 +448,11 @@ function wsl_process_login_get_user_data( $provider, $redirect_to )
                 {
                         return wsl_process_login_render_notice_page( _wsl__( "Registration is now closed.", 'wordpress-social-login' ) );
                 }
+				// Bouncer :: Only accept new connections for existing users?
+				else if (get_option( 'wsl_settings_bouncer_registration_enabled' ) == 3 && !email_exists($hybridauth_user_email))
+				{
+						return wsl_process_login_render_notice_page( _wsl__( "Only connections for existing users are allowed.", 'wordpress-social-login' ) );
+				}
 
                 // Bouncer::Accounts linking/mapping
                 // > > not implemented yet! Planned for WSL 2.3


### PR DESCRIPTION
In my project I needed to allow logins via Facebook, but not allow registration via Facebook, because the users have to fill out a complex form before registering.

So I added a new option to the bouncer's  "Accept new registration" menu:
"No, but allow existing users to connect". With this option selected,
only already registered users can login via social websites.
