### PR TITLE
Fix FB SDK warning about size of popup

### DIFF
--- a/assets/js/widget.js
+++ b/assets/js/widget.js
@@ -21,8 +21,8 @@
 
 			provider = $(this).attr("data-provider");
 
-			var width  = 1000;
-			var height = 600;
+			var width  = 580;
+			var height = 400;
 			var top    = ( screen.height / 2 ) - ( height / 2 ) - 50;
 			var left   = ( screen.width  / 2 ) - ( width  / 2 );
 


### PR DESCRIPTION
Warning is something like this: 
You are using a display type of 'popup' in a large browser window or tab. For a better experience, show this dialog with our JavaScript SDK...
This warning is shown to developers only but it improves user experience as per Facebook guidelines