### PR TITLE
Added site url in redirect uri

### DIFF
--- a/wp-social-login.php
+++ b/wp-social-login.php
@@ -94,7 +94,7 @@ defined( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH' )
 	|| define( 'WORDPRESS_SOCIAL_LOGIN_ABS_PATH', plugin_dir_path( __FILE__ ) );
 
 defined( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL' )
-	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+	|| define( 'WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL', site_url() . plugin_dir_url( __FILE__ ) );
 
 defined( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL' )
 	|| define( 'WORDPRESS_SOCIAL_LOGIN_HYBRIDAUTH_ENDPOINT_URL', WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . 'hybridauth/' );


### PR DESCRIPTION
To get facebook auth working. ref: https://wordpress.org/support/topic/the-redirect_uri-url-must-be-absolute-oauth-settings-facebook/