### PR TITLE
Added filter that allows overriding the redirect url when a new account is created

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -338,6 +338,7 @@ function wsl_process_login_end()
 			$user_id = wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, $requested_user_login, $requested_user_email );
 
 			$is_new_user = true;
+			$redirect_to = apply_filters('wsl_redirect_after_registration', $redirect_to);
 		}else{
 			$user_id = $wordpress_user_id;
 			$is_new_user = false;
@@ -1219,5 +1220,15 @@ function wsl_process_login_check_php_session()
 		return true;
 	}
 }
+
+// --------------------------------------------------------------------
+
+/**
+ * Returns redirect url for when a new account was created
+ */
+function wsl_new_register_redirect_url($redirect_to) {
+	return $redirect_to;
+}
+add_filter("wsl_redirect_after_registration", "wsl_new_register_redirect_url", 10, 1);
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
I need the functionality to redirect the user to a new URL if and only if a new wordpress account is created when they login with wordpress social login. I saw that this functionality was also requested by someone else: https://github.com/miled/wordpress-social-login/issues/113

When a user logins with wordpress social login and they already have an account, nothing will change. Everything will function exactly how it is.

When a user logins with wordpress social login and a new account is created for them, they will be redirected just like they would now, but you have the ability to override this functionality by adding a filter _wsl_redirect_after_registration_ to functions.php (or some other file).