### PR TITLE
Make user_login be unique regardless of status of !$user_login at wsl_process_login_create_wp_user

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -628,23 +628,23 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		{
 			$user_login = sanitize_user( current( explode( '@', $user_email ) ), true );
 		}
-
-		// user name should be unique
-		if( username_exists( $user_login ) )
-		{
-			$i = 1;
-			$user_login_tmp = $user_login;
-
-			do
-			{
-				$user_login_tmp = $user_login . "_" . ($i++);
-			}
-			while( username_exists ($user_login_tmp));
-
-			$user_login = $user_login_tmp;
-		}
 	}
-        
+
+	// user name should be unique
+	if( username_exists( $user_login ) )
+	{
+		$i = 1;
+		$user_login_tmp = $user_login;
+
+		do
+		{
+			$user_login_tmp = $user_login . "_" . ($i++);
+		}
+		while( username_exists ($user_login_tmp));
+
+		$user_login = $user_login_tmp;
+	}
+
 	if( ! $user_email )
 	{
 		$user_email = $hybridauth_user_profile->email;


### PR DESCRIPTION
Currently if a user exists in the db with a given user_login value (let's say "Matt_Rabe"), and someone then tries to log in for the first time using facebook (thus creating a new user account), and that person's facebook name is "Matt Rabe", this plugin will generate "Matt_Rabe" as a user_login for them, and the script fails. This appears to be because the routine to enforce uniqueness on user_login only runs `if( ! $user_login )` (includes/services/wsl.authentication.php line 614)...

This pull request moves the routine to enforce user_login uniqueness to outside of the `if( ! $user_login )` conditional, therefore avoiding this problem.