### PR TITLE
Prevent error "User login can't be empty"

### DIFF
--- a/includes/services/wsl.authentication.php
+++ b/includes/services/wsl.authentication.php
@@ -626,7 +626,12 @@ function wsl_process_login_create_wp_user( $provider, $hybridauth_user_profile, 
 		// if user profile display name is not provided
 		if( empty( $user_login ) )
 		{
-			$user_login = sanitize_user( current( explode( '@', $user_email ) ), true );
+			// may be that $user_email is empty then we got wp error login can't be empty, so check it now
+			if ( $user_email ) {
+				$user_login = sanitize_user( current( explode( '@', $user_email ) ), true );
+			} else {
+				$user_login = sanitize_user( current( explode( '@', $hybridauth_user_profile->email ) ), true );		
+			}
 		}
 
 		// user name should be unique


### PR DESCRIPTION
When **$user_login** after sanitize functions becomes empty, we try get it from **$user_email**, but in this moment **$user_email** can be empty, then **$user_login** becomes empty and we get error "User login can't be empty".
Can we check it by something like this and get **$user_login** from **$hybridauth_user_profile->email**?