### PR TITLE
Fix wrong user table prefix

### DIFF
--- a/includes/services/wsl.user.data.php
+++ b/includes/services/wsl.user.data.php
@@ -45,7 +45,7 @@ function wsl_get_wordpess_users_count()
 {
 	global $wpdb;
 
-	$sql = "SELECT COUNT( * ) AS items FROM `{$wpdb->prefix}users`"; 
+	$sql = "SELECT COUNT( * ) AS items FROM `{$wpdb->base_prefix}users`";
 
 	return $wpdb->get_var( $sql );
 }


### PR DESCRIPTION
The user table is shared and needs `base_prefix` instead of `prefix`