### PR TITLE
Update wp-social-login.php

### DIFF
--- a/wp-social-login.php
+++ b/wp-social-login.php
@@ -261,3 +261,25 @@ if( is_admin() && ( !defined( 'DOING_AJAX' ) || !DOING_AJAX ) )
 }
 
 // --------------------------------------------------------------------
+
+// --------------------------------------------------------------------
+
+/**
+* Facebook login fix.
+*
+* https://wordpress.org/support/topic/error-when-logging-with-fb/#post-10347261
+*/
+
+function wsl_change_default_permissons( $provider_scope, $provider )
+{
+	if( 'facebook' == strtolower( $provider ) )
+	{
+		$provider_scope = 'email, public_profile';
+	}
+
+	return $provider_scope;
+}
+
+add_filter( 'wsl_hook_alter_provider_scope', 'wsl_change_default_permissons', 10, 2 );
+
+// --------------------------------------------------------------------


### PR DESCRIPTION
This update is to fix the error when trying to logging with Facebook. The error is:

"Invalid Scopes: user_friends. This message is only shown to developers. Users of your app will ignore these permissions if present. Please read the documentation for valid permissions at https://developers.facebook.com/docs/f…ermissions"

This fix was proposed by Miled here: https://wordpress.org/support/topic/error-when-logging-with-fb/#post-10347261