### PR TITLE
Bug Fix: 'missing scope' while auth with Google

### DIFF
--- a/hybridauth/library/src/Provider/Google.php
+++ b/hybridauth/library/src/Provider/Google.php
@@ -82,6 +82,8 @@ class Google extends OAuth2
         $this->AuthorizeUrlParameters += [
             'access_type' => 'offline'
         ];
+        
+        $this->AuthorizeUrlParameters['scope'] = 'profile https://www.googleapis.com/auth/plus.profile.emails.read';
 
         $this->tokenRefreshParameters += [
             'client_id' => $this->clientId,


### PR DESCRIPTION
Added a line that fixes a bug with 'missing scope' in Google.