### PR TITLE
Avoid ERR_INVALID_REDIRECT ignoring $request_port if $request_host already contains it

### DIFF
--- a/includes/services/wsl.utilities.php
+++ b/includes/services/wsl.utilities.php
@@ -93,6 +93,9 @@ function wsl_get_current_url()
 	//Remove standard ports
 	$request_port = (!in_array($request_port, array (80, 443)) ? $request_port : '');
 
+	//Ignore $request_port if $request_host already contains it
+	$request_port = ( substr_compare( $request_host, ":$request_port", -strlen( ":$request_port" ) ) === 0 ? '' : $request_port );
+
 	//Build url
 	$current_url = $request_protocol . '://' . $request_host . ( ! empty ($request_port) ? (':'.$request_port) : '') . $request_uri;
 


### PR DESCRIPTION
I'm using [wordpress:php5.6 Docker image](https://hub.docker.com/_/wordpress/) on my dev env and when `Hybrid_Auth::getCurrentUrl()` is invoked it returns the port twice.

![image](https://user-images.githubusercontent.com/22457494/45260048-c24a4d00-b3b2-11e8-8658-a10f06f32145.png)