### PR TITLE
Errors saying users table doesn't exist on Multisite Install

### DIFF
--- a/includes/services/wsl.user.data.php
+++ b/includes/services/wsl.user.data.php
@@ -45,7 +45,7 @@ function wsl_get_wordpess_users_count()
 {
 	global $wpdb;
 
-	$sql = "SELECT COUNT( * ) AS items FROM `{$wpdb->prefix}users`"; 
+	$sql = "SELECT COUNT( * ) AS items FROM `$wpdb->users`";           
 
 	return $wpdb->get_var( $sql );
 }
@@ -452,3 +452,4 @@ function wsl_delete_stored_hybridauth_user_data( $user_id )
 add_action( 'delete_user', 'wsl_delete_stored_hybridauth_user_data' );
 
 // --------------------------------------------------------------------
+?>


### PR DESCRIPTION
On a multisite install, I am getting errors that the users table doesn't exist. It is looking for the users table at wp_22_users using the prefix for the one site we are using it on. With a multisite install, the users table is typically wp_users and shared across the sites.

You should be able to fix that here: https://github.com/miled/wordpress-social-login/blob/master/includes/services/wsl.user.data.php#L48

By replacing {$wpdb->prefix}users with $wpdb->users which calls the users table.