### PR TITLE
Providers: Odnoklassniki: App ID and Key settings

### DIFF
--- a/includes/admin/components/networks/wsl.components.networks.setup.php
+++ b/includes/admin/components/networks/wsl.components.networks.setup.php
@@ -134,7 +134,9 @@ function wsl_component_networks_setup()
 									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_id' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_id' ); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
 								</tr>
-							<?php } else { ?>
+							<?php } ?>
+							
+							<?php if( !$require_client_id || $require_client_id === 'both' ) { ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
 									<td><?php _wsl_e("Application Key", 'wordpress-social-login') ?>:</td>
 									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_key' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_key' ); ?>" ></td>

--- a/includes/settings/wsl.initialization.php
+++ b/includes/settings/wsl.initialization.php
@@ -227,7 +227,8 @@ function wsl_register_setting()
 			{
 				register_setting( 'wsl-settings-group', 'wsl_settings_' . $provider_id . '_app_id' ); 
 			}
-			else
+			
+            if( !$require_client_id || $require_client_id === 'both' )
 			{
 				register_setting( 'wsl-settings-group', 'wsl_settings_' . $provider_id . '_app_key' ); 
 			}

--- a/includes/settings/wsl.providers.php
+++ b/includes/settings/wsl.providers.php
@@ -158,7 +158,7 @@ $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG = ARRAY(
 	ARRAY(
 		"provider_id"       => "Odnoklassniki",
 		"provider_name"     => "Odnoklassniki",
-		"require_client_id" => true,
+		"require_client_id" => "both",
 		"callback"          => true,
 		"new_app_link"      => "http://dev.odnoklassniki.ru/",
 	),


### PR DESCRIPTION
_Odnoklassniki_ provider requires app **ID** and **Key**. Current admin UI allows to set only one of them. This change **adds ability** to any provider to **use both** settings.