### PR TITLE
Replacing icon16 with dashicons

### DIFF
--- a/includes/admin/components/components/wsl.components.help.setup.php
+++ b/includes/admin/components/components/wsl.components.help.setup.php
@@ -62,11 +62,11 @@ function wsl_component_components_setup()
 				<tr id="<?php echo $name ?>" class="<?php echo $name ?> <?php echo $plugin_tr_class ?>"> 
 					<td class="component-label" style="width: 190px;"> &nbsp;
 						<?php if( $settings["type"] == "core" ): ?>
-							<div class="icon16 icon-generic"></div>
+							<span class="dashicons-before dashicons-admin-generic toggle-indicator alignleft" aria-hidden="true"></span>
 						<?php elseif( $settings["type"] == "addon" ): ?>
-							<div class="icon16 icon-plugins"></div>
+							<span class="dashicons-before dashicons-admin-plugins toggle-indicator alignleft" aria-hidden="true"></span>
 						<?php else: ?>
-							<div class="icon16 icon-appearance"></div>
+							<span class="dashicons-before dashicons-admin-appearance toggle-indicator alignleft" aria-hidden="true"></span>
 						<?php endif; ?>
 						
 						<strong><?php _wsl_e( $settings["label"], 'wordpress-social-login' ) ?></strong> 


### PR DESCRIPTION
Looking at [WordPress Trac #35717](https://core.trac.wordpress.org/ticket/35717), the old `icon16` classes may be deprecated soon.

The dashicons collection could replace those:
- using `toggle-indicator` class for the gray color
- adding `alignleft` to float the icon (with that, it can remain a `div`, but I had already changed it to a `span`)
- including `aria-hidden="true"` so screen readers do not try reading the icon character

**Screenshot before:**

![before](https://user-images.githubusercontent.com/17100257/110544596-9f1ec680-80f1-11eb-8a6b-271e3cce0fc6.png)

**After changes,** icons are slightly darker and align to the top of the cell:

![after](https://user-images.githubusercontent.com/17100257/110544615-a80f9800-80f1-11eb-842f-c17d0501e6a7.png)
